### PR TITLE
Fix minor typos in grid info and reload util

### DIFF
--- a/src/components/BottomGridInfo.vue
+++ b/src/components/BottomGridInfo.vue
@@ -9,7 +9,7 @@
     
     <span class="text-nowrap">🔗 url:{{ displayUrl }}</span>
 
-    <span class="flex items-cente text-nowrapr">
+    <span class="flex items-center text-nowrap">
       <img
         :src="getImageSrc('/images/sand-shovel.png').value"
         alt="Shovel"

--- a/src/composables/useSoftReload.js
+++ b/src/composables/useSoftReload.js
@@ -6,7 +6,7 @@ export function useSoftReload () {
   const router = useRouter()
 
   const softReload = () => {
-    console.log('softReload edd');
+    console.log('Soft reload triggered');
     router.replace({
       path: route.path,
       query: { ...route.query, __t: Date.now() }


### PR DESCRIPTION
## Summary
- fix typo in BottomGridInfo CSS classes
- tidy debug log in useSoftReload

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688896f04f3c83248c74d68dc14d6939