### PR TITLE
Trim "/digging" from the compact bottom URL display so it shows clean…

### DIFF
--- a/src/components/BottomGridInfo.vue
+++ b/src/components/BottomGridInfo.vue
@@ -78,8 +78,15 @@ const displayUrl = computed(() => {
     const currentUrl = new URL(window.location.href)
     let path = route.path || currentUrl.pathname
 
+    // Keep URL display compact on digging pages.
+    path = path.replace(/\/digging\/?$/, '')
+
     if (!props.showLandIdInUrl) {
       path = path.replace(/^\/\d+(?=\/|$)/, '') || '/'
+    }
+
+    if (!path || path === '/') {
+      return currentUrl.host
     }
 
     return `${currentUrl.host}${path}`


### PR DESCRIPTION
…er land links like host/id.