### PR TITLE
Preserve practice snapshot dates in cache.

### DIFF
--- a/src/composables/useLandData.js
+++ b/src/composables/useLandData.js
@@ -2,7 +2,11 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useStorage } from '@vueuse/core'
-import { PRACTICE_PATTERN_CACHE_KEY, usePracticePatterns } from '@/composables/usePracticePatterns.js'
+import {
+  PRACTICE_PATTERN_CACHE_KEY,
+  PRACTICE_PATTERN_CACHE_VERSION,
+  usePracticePatterns,
+} from '@/composables/usePracticePatterns.js'
 
 export function useLandData (defaults = {}) {
   const route = useRoute()
@@ -25,6 +29,7 @@ export function useLandData (defaults = {}) {
   }
 
   const practicePatternCache = useStorage(PRACTICE_PATTERN_CACHE_KEY, {
+    version: PRACTICE_PATTERN_CACHE_VERSION,
     date: '',
     fetchedAt: 0,
     patterns: [],
@@ -36,7 +41,10 @@ export function useLandData (defaults = {}) {
   const patternKeys = computed(() => desert.value.digging?.patterns || [])
   const dailyPatternKeys = computed(() => {
     const cached = practicePatternCache.value
-    return cached?.date === todayUTC && Array.isArray(cached.patterns)
+    return cached?.version === PRACTICE_PATTERN_CACHE_VERSION
+      && typeof cached?.date === 'string'
+      && cached.date
+      && Array.isArray(cached.patterns)
       ? cached.patterns
       : []
   })
@@ -49,7 +57,12 @@ export function useLandData (defaults = {}) {
     ;(async () => {
       try {
         const cached = practicePatternCache.value
-        if (cached?.date === todayUTC && Array.isArray(cached.patterns) && cached.patterns.length) {
+        if (
+          cached?.version === PRACTICE_PATTERN_CACHE_VERSION
+          && cached?.date === todayUTC
+          && Array.isArray(cached.patterns)
+          && cached.patterns.length
+        ) {
           return
         }
 

--- a/src/composables/usePracticePatterns.js
+++ b/src/composables/usePracticePatterns.js
@@ -4,12 +4,19 @@ import { fetchPracticePatterns } from '@/services/practicePatternService'
 import { PRACTICE_CONSTANTS } from '@/data/app/constants'
 
 const getTodayUTC = () => new Date().toISOString().slice(0, 10)
+const UTC_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+export const PRACTICE_PATTERN_CACHE_VERSION = 2
+
+function normalizeUTCDate (value) {
+  return typeof value === 'string' && UTC_DATE_PATTERN.test(value) ? value : ''
+}
 
 const cacheKey = `practice:today-patterns:${PRACTICE_CONSTANTS.ADAM_OWNER_ID}`
 
 export const PRACTICE_PATTERN_CACHE_KEY = cacheKey
 
 const defaultCache = {
+  version: PRACTICE_PATTERN_CACHE_VERSION,
   date: '',
   fetchedAt: 0,
   landId: PRACTICE_CONSTANTS.ADAM_OWNER_ID,
@@ -26,6 +33,7 @@ function readCachedPatternsFromStorage () {
     const raw = window.localStorage?.getItem(cacheKey)
     if (!raw) return []
     const parsed = JSON.parse(raw)
+    if (parsed?.version !== PRACTICE_PATTERN_CACHE_VERSION) return []
     if (parsed?.date !== getTodayUTC()) return []
     return Array.isArray(parsed.patterns) ? parsed.patterns : []
   } catch (error) {
@@ -43,7 +51,11 @@ export function usePracticePatterns () {
   const isLoading = ref(false)
   const error = ref('')
 
-  const isCachedForToday = computed(() => cache.value.date === getTodayUTC() && (cache.value.patterns || []).length > 0)
+  const isCachedForToday = computed(() => (
+    cache.value.version === PRACTICE_PATTERN_CACHE_VERSION
+    && cache.value.date === getTodayUTC()
+    && (cache.value.patterns || []).length > 0
+  ))
   const patternKeys = computed(() => (isCachedForToday.value ? cache.value.patterns : []))
 
   async function refreshPracticePatterns ({ force = false } = {}) {
@@ -68,12 +80,19 @@ export function usePracticePatterns () {
         const fresh = await fetchPracticePatterns()
         const visitedFarmState = fresh?.visitedFarmState || {}
         const patterns = visitedFarmState.desert?.digging?.patterns || []
+        const snapshotDate = normalizeUTCDate(fresh?.date) || getTodayUTC()
+        const isStaleSnapshot = snapshotDate !== getTodayUTC()
 
         cache.value = {
-          date: getTodayUTC(),
+          version: PRACTICE_PATTERN_CACHE_VERSION,
+          date: snapshotDate,
           fetchedAt: Date.now(),
           landId: PRACTICE_CONSTANTS.ADAM_OWNER_ID,
           patterns,
+        }
+
+        if (isStaleSnapshot) {
+          throw new Error(`Loaded stale practice patterns for ${snapshotDate}.`)
         }
 
         return cache.value

--- a/src/services/practicePatternService.js
+++ b/src/services/practicePatternService.js
@@ -1,20 +1,37 @@
 const PRACTICE_PATTERN_ENDPOINT = '/api/practice-patterns'
 const getTodayUTC = () => new Date().toISOString().slice(0, 10)
+const UTC_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
-function normalizePracticePayload (data) {
+function normalizeUTCDate (value) {
+  return typeof value === 'string' && UTC_DATE_PATTERN.test(value) ? value : ''
+}
+
+function normalizePracticePayload (data, responseDate = '') {
+  const date = normalizeUTCDate(data?.date) || normalizeUTCDate(responseDate)
+
   if (!data) {
-    return { visitedFarmState: {} }
+    return { date, visitedFarmState: {} }
   }
 
   if (data.visitedFarmState) {
-    return data
+    return {
+      ...data,
+      date,
+    }
   }
 
   if (data.farm) {
-    return { visitedFarmState: data.farm }
+    return {
+      ...data,
+      date,
+      visitedFarmState: data.farm,
+    }
   }
 
-  return { visitedFarmState: data }
+  return {
+    date,
+    visitedFarmState: data,
+  }
 }
 
 export async function fetchPracticePatterns () {
@@ -30,5 +47,5 @@ export async function fetchPracticePatterns () {
   }
 
   const payload = await response.json()
-  return normalizePracticePayload(payload)
+  return normalizePracticePayload(payload, response.headers.get('x-pattern-date') || '')
 }


### PR DESCRIPTION
This prevents stale daily pattern payloads from being relabeled as today's data and forces affected browsers to refresh invalid cached entries.