### PR TITLE
Add dig-day persistence with mark journal and Netlify Blobs API.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ Then open `http://localhost:5173` in your browser.
 
 ---
 
+## Dig day blob storage
+
+Per-land dig snapshots (patterns, dig timeline, mark events) are stored in **Netlify Blobs** via `/api/dig-day`. See [netlify/functions/README.md](netlify/functions/README.md) for GET/POST usage and how to retrieve data from the dashboard or CLI.
+
+---
+
 ## 🧠 Tech Stack
 
 * Vue 3 (Composition API)

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,6 +25,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/dig-day"
+  to = "/.netlify/functions/dig-day"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -1,0 +1,24 @@
+# Netlify Functions
+
+## Dig day snapshots (`dig-day`)
+
+Stores lean per-land, per-UTC-date dig history in Netlify Blobs store `dig-day-snapshots`.
+
+- **GET** `/api/dig-day?landId=12345&utcDate=2026-05-18`
+- **POST** `/api/dig-day` with JSON body (`v`, `landId`, `utcDate`, `patterns`, `digs`, `markEvents`, `stats`)
+
+Data is public by `landId` in v1 (no ownership). Mark events merge append-only by `seq`.
+
+### Retrieve blobs
+
+1. **App API** — URLs above (primary).
+2. **Netlify dashboard** — Site → Storage → Blobs → `dig-day-snapshots` → keys like `12345/2026-05-18.json`.
+3. **Netlify CLI**:
+   ```bash
+   netlify blobs:list --store dig-day-snapshots
+   netlify blobs:get dig-day-snapshots 12345/2026-05-18.json
+   ```
+
+## Practice patterns (`practice-patterns`)
+
+Daily pattern cache in store `practice-daily-patterns`. See `_practiceDailyStore.js`.

--- a/netlify/functions/_digDayStore.js
+++ b/netlify/functions/_digDayStore.js
@@ -1,0 +1,131 @@
+const { getStore } = require('@netlify/blobs')
+
+const STORE_NAME = 'dig-day-snapshots'
+const MAX_MARK_EVENTS = 500
+const MAX_BLOB_BYTES = 256 * 1024
+
+function getTodayUTC () {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function parseUTCDate (value) {
+  if (typeof value !== 'string') return getTodayUTC()
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : getTodayUTC()
+}
+
+function isValidLandId (landId) {
+  return typeof landId === 'string' && /^\d{1,12}$/.test(landId)
+}
+
+function blobKey (landId, utcDate) {
+  return `${landId}/${utcDate}.json`
+}
+
+function emptySnapshot (landId, utcDate) {
+  return {
+    v: 1,
+    landId,
+    utcDate,
+    patterns: [],
+    digs: [],
+    markEvents: [],
+    stats: { totalDigs: 0, treasureCount: 0 },
+    updatedAt: null,
+  }
+}
+
+function mergeMarkEvents (existing, incoming) {
+  const bySeq = new Map()
+  for (const e of existing || []) {
+    if (e?.seq != null) bySeq.set(e.seq, e)
+  }
+  for (const e of incoming || []) {
+    if (e?.seq != null) bySeq.set(e.seq, e)
+  }
+  const merged = [...bySeq.values()].sort((a, b) => a.seq - b.seq)
+  return merged.slice(-MAX_MARK_EVENTS)
+}
+
+function shouldReplaceDigs (existing, incoming) {
+  if (!existing?.digs?.length) return true
+  if (!incoming?.digs?.length) return false
+
+  const existingLen = existing.digs.length
+  const incomingLen = incoming.digs.length
+  if (incomingLen > existingLen) return true
+  if (incomingLen < existingLen) return false
+
+  const existingAt = existing.updatedAt ? Date.parse(existing.updatedAt) : 0
+  const incomingAt = incoming.updatedAt ? Date.parse(incoming.updatedAt) : 0
+  return incomingAt >= existingAt
+}
+
+function mergeDigDay (existing, incoming) {
+  const landId = incoming.landId
+  const utcDate = incoming.utcDate
+  const base = existing || emptySnapshot(landId, utcDate)
+
+  const replaceDigs = shouldReplaceDigs(base, incoming)
+
+  const merged = {
+    v: 1,
+    landId,
+    utcDate,
+    patterns: replaceDigs
+      ? [...(incoming.patterns || [])]
+      : [...(base.patterns || [])],
+    digs: replaceDigs ? [...(incoming.digs || [])] : [...(base.digs || [])],
+    markEvents: mergeMarkEvents(base.markEvents, incoming.markEvents),
+    stats: replaceDigs
+      ? { ...(incoming.stats || {}) }
+      : { ...(base.stats || {}) },
+    updatedAt: new Date().toISOString(),
+  }
+
+  const json = JSON.stringify(merged)
+  if (json.length > MAX_BLOB_BYTES) {
+    const err = new Error('Snapshot too large')
+    err.statusCode = 413
+    throw err
+  }
+
+  return merged
+}
+
+async function getDigDay (landId, utcDate) {
+  const store = getStore(STORE_NAME)
+  return store.get(blobKey(landId, utcDate), { type: 'json' })
+}
+
+async function saveDigDay (payload) {
+  const landId = String(payload.landId || '')
+  const utcDate = parseUTCDate(payload.utcDate)
+
+  if (!isValidLandId(landId)) {
+    const err = new Error('Invalid landId')
+    err.statusCode = 400
+    throw err
+  }
+
+  const store = getStore(STORE_NAME)
+  const existing = await getDigDay(landId, utcDate)
+  const merged = mergeDigDay(existing, {
+    ...payload,
+    landId,
+    utcDate,
+  })
+
+  await store.setJSON(blobKey(landId, utcDate), merged)
+  return merged
+}
+
+module.exports = {
+  STORE_NAME,
+  getTodayUTC,
+  parseUTCDate,
+  isValidLandId,
+  emptySnapshot,
+  getDigDay,
+  saveDigDay,
+  mergeDigDay,
+}

--- a/netlify/functions/dig-day.js
+++ b/netlify/functions/dig-day.js
@@ -1,0 +1,148 @@
+const { connectLambda } = require('@netlify/blobs')
+const {
+  getTodayUTC,
+  parseUTCDate,
+  isValidLandId,
+  emptySnapshot,
+  getDigDay,
+  saveDigDay,
+} = require('./_digDayStore')
+
+const CORS_ORIGINS = [
+  'https://d1g.uk',
+  'https://beta.d1g.uk',
+  'https://development.d1g.uk',
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+]
+
+// Per-instance rate limit (best-effort on serverless)
+const rateBuckets = new Map()
+const RATE_LIMIT = 30
+const RATE_WINDOW_MS = 60_000
+
+function initBlobContext (event) {
+  try {
+    connectLambda(event)
+  } catch {
+    // Non-compat runtimes may already provide context
+  }
+}
+
+function corsHeaders (origin) {
+  const allowed =
+    !origin ||
+    CORS_ORIGINS.includes(origin) ||
+    /^https:\/\/[\w-]+--[\w-]+\.netlify\.app$/.test(origin)
+
+  return {
+    'Access-Control-Allow-Origin': allowed ? origin || CORS_ORIGINS[0] : CORS_ORIGINS[0],
+    'Access-Control-Allow-Headers': 'Content-Type, Accept',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  }
+}
+
+function getClientIp (event) {
+  return (
+    event.headers['x-nf-client-connection-ip'] ||
+    event.headers['client-ip'] ||
+    event.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    'unknown'
+  )
+}
+
+function checkRateLimit (ip) {
+  const now = Date.now()
+  let bucket = rateBuckets.get(ip)
+  if (!bucket || now - bucket.start > RATE_WINDOW_MS) {
+    bucket = { start: now, count: 0 }
+    rateBuckets.set(ip, bucket)
+  }
+  bucket.count += 1
+  if (bucket.count > RATE_LIMIT) {
+    const err = new Error('Too many requests')
+    err.statusCode = 429
+    throw err
+  }
+}
+
+exports.handler = async (event) => {
+  initBlobContext(event)
+  const origin = event.headers.origin || event.headers.Origin
+  const headers = {
+    'Content-Type': 'application/json',
+    ...corsHeaders(origin),
+  }
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers, body: '' }
+  }
+
+  try {
+    checkRateLimit(getClientIp(event))
+  } catch (err) {
+    return {
+      statusCode: err.statusCode || 429,
+      headers,
+      body: JSON.stringify({ error: err.message }),
+    }
+  }
+
+  try {
+    if (event.httpMethod === 'GET') {
+      const landId = String(event.queryStringParameters?.landId || '')
+      const utcDate = parseUTCDate(event.queryStringParameters?.utcDate)
+
+      if (!isValidLandId(landId)) {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Invalid landId' }),
+        }
+      }
+
+      const snapshot = await getDigDay(landId, utcDate)
+      if (!snapshot) {
+        return {
+          statusCode: 404,
+          headers,
+          body: JSON.stringify(emptySnapshot(landId, utcDate)),
+        }
+      }
+
+      return {
+        statusCode: 200,
+        headers: {
+          ...headers,
+          'Cache-Control': 'public, max-age=30, must-revalidate',
+        },
+        body: JSON.stringify(snapshot),
+      }
+    }
+
+    if (event.httpMethod === 'POST') {
+      const payload = JSON.parse(event.body || '{}')
+      const merged = await saveDigDay(payload)
+      return {
+        statusCode: 200,
+        headers: { ...headers, 'Cache-Control': 'no-store' },
+        body: JSON.stringify(merged),
+      }
+    }
+
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    }
+  } catch (error) {
+    console.error('dig-day:', error)
+    return {
+      statusCode: error.statusCode || 500,
+      headers,
+      body: JSON.stringify({
+        error: error.message || 'Internal server error',
+      }),
+    }
+  }
+}

--- a/src/components/DigToolSection.vue
+++ b/src/components/DigToolSection.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="flex gap-4 mb-1 justify-center items-center">
+  <div class="flex flex-col gap-1 mb-1">
+  <p v-if="digDaySyncLabel" class="text-center text-[0.65rem] text-base-content/60 m-0">
+    {{ digDaySyncLabel }}
+  </p>
+  <div class="flex gap-4 justify-center items-center">
     <InputLandIdOrRefresh />
     <button
       type="button"
@@ -67,25 +71,57 @@
       </div>
     </div>
   </div>
+  </div>
 
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useGridManager } from '@/composables/useGridManager'
 import InputLandIdOrRefresh from '@/components/InputLandIdOrRefresh.vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const route  = useRoute()
 const router = useRouter()
-// grid.clear() still lives here
 const landId = route.params.landId || '0'
 const grid = useGridManager(landId)
 
-// Define the incoming prop and the event you'll emit
-defineProps({
+// Public dig-day snapshots: data is keyed by landId + UTC date (no ownership in v1).
+const props = defineProps({
   showTreasureOrder: { type: Boolean, default: false },
   hideLandIdInUrl: { type: Boolean, default: false },
+  digDaySyncStatus: { type: String, default: 'idle' },
+  digDayUpdatedAt: { type: String, default: null },
 })
+
+const digDaySyncLabel = computed(() => {
+  if (!route.params.landId) return ''
+  switch (props.digDaySyncStatus) {
+    case 'loading':
+      return 'Loading saved dig day…'
+    case 'syncing':
+      return 'Saving dig day…'
+    case 'saved':
+      return props.digDayUpdatedAt
+        ? `Dig day saved · ${formatShortTime(props.digDayUpdatedAt)}`
+        : 'Dig day saved'
+    case 'error':
+      return 'Dig day sync failed (will retry on next change)'
+    default:
+      return ''
+  }
+})
+
+function formatShortTime (iso) {
+  try {
+    return new Date(iso).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return ''
+  }
+}
 // we'll emit update:showTreasureOrder via @change above
 defineEmits(['update:showTreasureOrder', 'update:hideLandIdInUrl'])
 

--- a/src/components/InfoFooter.vue
+++ b/src/components/InfoFooter.vue
@@ -17,9 +17,20 @@
           >
             sfl.world/land/1/treasures
           </a>
-          digging guide of sfl.world. A personal tool to assist Sunflower Land players
-          with digging. You can visualize hint patterns (sand, crab, treasure)
+          digging guide of sfl.world. An unofficial fan tool to assist
+          <a
+            href="https://sunflower-land.com"
+            target="_blank"
+            rel="noopener"
+            class="link link-primary"
+          >Sunflower Land</a>
+          players with digging. You can visualize hint patterns (sand, crab, treasure)
           and simulate digging logic with interactive tiles.
+        </p>
+        <p class="mt-2 text-sm text-base-content/70">
+          Not affiliated with Thought Farm or Sunflower Land. Game assets and mechanics
+          belong to their respective owners. Practice mode is a training simulator only —
+          it does not award in-game items or affect your farm.
         </p>
       </div>
 

--- a/src/composables/markJournalBridge.js
+++ b/src/composables/markJournalBridge.js
@@ -1,0 +1,22 @@
+/** Per-land callbacks wired by useDigDayStore for useGridManager pick/clear. */
+const handlersByLand = new Map()
+
+/**
+ * @param {string} landId
+ * @param {{ getAfterDigOrder: () => number, onPick: (index: number, hintClass: string|string[]) => void, onClearAll: () => void } | null} handlers
+ */
+export function registerMarkJournalHandlers (landId, handlers) {
+  if (!landId || landId === 'guest' || landId === '0') {
+    handlersByLand.delete(landId)
+    return
+  }
+  if (handlers) {
+    handlersByLand.set(String(landId), handlers)
+  } else {
+    handlersByLand.delete(String(landId))
+  }
+}
+
+export function getMarkJournalHandlers (landId) {
+  return handlersByLand.get(String(landId)) || null
+}

--- a/src/composables/useDigDayStore.js
+++ b/src/composables/useDigDayStore.js
@@ -1,0 +1,177 @@
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import {
+  buildDigTimeline,
+  buildDigStats,
+  getCurrentDigOrder,
+  getTodayUTC,
+} from '@/utils/buildDigTimeline.js'
+import { useMarkJournal, getMarkEventsSnapshot } from '@/composables/useMarkJournal.js'
+import { registerMarkJournalHandlers } from '@/composables/markJournalBridge.js'
+import { fetchDigDay, saveDigDay } from '@/services/digDayApiService.js'
+
+const instances = new Map()
+const SYNC_DEBOUNCE_MS = 400
+
+function isPersistableLandId (landId) {
+  const id = String(landId || '')
+  return id && id !== 'guest' && id !== '0' && /^\d+$/.test(id)
+}
+
+const noopStore = {
+  syncStatus: ref('idle'),
+  lastUpdatedAt: ref(null),
+  loadFromServer: async () => {},
+  scheduleSync: () => {},
+  upsertFromApi: () => {},
+}
+
+/**
+ * Per landId + UTC date: sync lean dig snapshot to Netlify Blobs (public, no ownership v1).
+ * @param {string} landId
+ * @param {import('vue').Ref | (() => object)} desertSource reactive desert or getter
+ */
+export function useDigDayStore (landId, desertSource) {
+  const key = String(landId || '')
+  if (!isPersistableLandId(key)) return noopStore
+
+  if (!instances.has(key)) {
+    const journal = useMarkJournal(key)
+    const syncStatus = ref('idle')
+    const lastUpdatedAt = ref(null)
+    let syncTimer = null
+    let lastPayloadJson = ''
+
+    function getDesert () {
+      const src = desertSource
+      if (typeof src === 'function') return src() || {}
+      return src?.value ?? src ?? {}
+    }
+
+    function buildPayload () {
+      const digging = getDesert().digging || {}
+      const rawGrid = digging.grid || []
+      const digs = buildDigTimeline(rawGrid)
+
+      return {
+        v: 1,
+        landId: key,
+        utcDate: getTodayUTC(),
+        patterns: [...(digging.patterns || [])],
+        digs,
+        markEvents: getMarkEventsSnapshot(key),
+        stats: buildDigStats(digs),
+        updatedAt: new Date().toISOString(),
+      }
+    }
+
+    function getAfterDigOrder () {
+      return getCurrentDigOrder(getDesert().digging?.grid || [])
+    }
+
+    registerMarkJournalHandlers(key, {
+      getAfterDigOrder,
+      onPick (index, hintClass) {
+        const order = getAfterDigOrder()
+        const flat = Array.isArray(hintClass) ? hintClass : [hintClass]
+        const isClear =
+          !flat.length ||
+          flat.some((c) => c === 'no-hint-and-show-trash-icon' || !c)
+        if (isClear) {
+          journal.recordClear(index, order)
+        } else {
+          journal.recordSet(index, hintClass, order)
+        }
+        scheduleSync()
+      },
+      onClearAll () {
+        journal.recordClearAll(getAfterDigOrder())
+        scheduleSync()
+      },
+    })
+
+    async function loadFromServer () {
+      syncStatus.value = 'loading'
+      try {
+        const remote = await fetchDigDay(key, getTodayUTC())
+        if (remote?.markEvents?.length) {
+          journal.mergeServerEvents(remote.markEvents)
+        }
+        if (remote?.updatedAt) {
+          lastUpdatedAt.value = remote.updatedAt
+        }
+        syncStatus.value = 'idle'
+      } catch (err) {
+        console.warn('dig-day load failed:', err)
+        syncStatus.value = 'error'
+      }
+    }
+
+    async function syncToServer () {
+      const payload = buildPayload()
+      const json = JSON.stringify(payload)
+      if (json === lastPayloadJson) return
+
+      syncStatus.value = 'syncing'
+      try {
+        const saved = await saveDigDay(payload)
+        lastPayloadJson = json
+        if (saved?.markEvents?.length) {
+          journal.mergeServerEvents(saved.markEvents)
+        }
+        lastUpdatedAt.value = saved?.updatedAt || payload.updatedAt
+        syncStatus.value = 'saved'
+      } catch (err) {
+        console.warn('dig-day sync failed:', err)
+        syncStatus.value = 'error'
+      }
+    }
+
+    function scheduleSync () {
+      if (syncTimer) clearTimeout(syncTimer)
+      syncTimer = setTimeout(() => {
+        syncTimer = null
+        syncToServer()
+      }, SYNC_DEBOUNCE_MS)
+    }
+
+    function upsertFromApi () {
+      scheduleSync()
+    }
+
+    watch(
+      () => getDesert().digging?.grid,
+      () => scheduleSync(),
+      { deep: true }
+    )
+
+    watch(
+      () => journal.events.value.length,
+      () => scheduleSync()
+    )
+
+    const store = {
+      syncStatus,
+      lastUpdatedAt,
+      loadFromServer,
+      scheduleSync,
+      upsertFromApi,
+      _cleanup () {
+        if (syncTimer) clearTimeout(syncTimer)
+        registerMarkJournalHandlers(key, null)
+      },
+    }
+
+    instances.set(key, store)
+
+    onMounted(() => {
+      loadFromServer()
+    })
+
+    onBeforeUnmount(() => {
+      store._cleanup()
+      instances.delete(key)
+    })
+  }
+
+  return instances.get(key)
+}

--- a/src/composables/useGridManager.js
+++ b/src/composables/useGridManager.js
@@ -1,6 +1,7 @@
 // src/composables/useGridManager.js
 import { useGridEngine } from './useGridEngine'
 import { useHintsStorage } from './useHintsStorage'
+import { getMarkJournalHandlers } from './markJournalBridge'
 
 const cache = {}
 
@@ -57,6 +58,9 @@ export function useGridManager (rawLandId, gridSize = 10) {
 
     // clear everything
     function clear () {
+      const journalHandlers = getMarkJournalHandlers(landKey)
+      journalHandlers?.onClearAll?.()
+
       // remove all hint-*/near-hint-* classes
       engine.clearEngineHints()
       // wipe out stored hints
@@ -88,6 +92,9 @@ export function useGridManager (rawLandId, gridSize = 10) {
         }
 
         storage.save();
+
+        const journalHandlers = getMarkJournalHandlers(landKey)
+        journalHandlers?.onPick?.(index, flat)
       },
       clear
     }

--- a/src/composables/useMarkJournal.js
+++ b/src/composables/useMarkJournal.js
@@ -1,0 +1,153 @@
+import { ref } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { getTodayUTC } from '@/utils/buildDigTimeline.js'
+
+const instances = new Map()
+
+function isTrashHint (hintClass) {
+  const flat = Array.isArray(hintClass) ? hintClass : [hintClass]
+  return flat.some(
+    (c) =>
+      c === 'no-hint-and-show-trash-icon' ||
+      c === '' ||
+      c == null
+  )
+}
+
+function normalizeClasses (hintClass) {
+  const flat = Array.isArray(hintClass) ? hintClass : [hintClass]
+  return flat.filter(Boolean)
+}
+
+/**
+ * Event log for custom marks (when placed relative to dig order).
+ * Public data model: keyed by landId + UTC date; no ownership in v1.
+ */
+export function useMarkJournal (landId) {
+  const key = String(landId || '')
+  if (!key || key === 'guest' || key === '0') {
+    return {
+      events: ref([]),
+      recordSet: () => {},
+      recordClear: () => {},
+      recordClearAll: () => {},
+      mergeServerEvents: () => {},
+      getMarksAtStep: () => ({}),
+      nextSeq: () => 0,
+    }
+  }
+
+  if (!instances.has(key)) {
+    const todayUTC = getTodayUTC()
+    const storageKey = `markJournal_${key}_${todayUTC}`
+
+    const events = useStorage(storageKey, [])
+
+    if (events.value?.length && events.value[0]?._date && events.value[0]._date !== todayUTC) {
+      events.value = []
+    }
+
+    let seqCounter = Math.max(0, ...events.value.map((e) => e.seq || 0))
+
+    function nextSeq () {
+      seqCounter += 1
+      return seqCounter
+    }
+
+    function recordSet (cell, classes, afterDigOrder) {
+      const normalized = normalizeClasses(classes)
+      if (!normalized.length || isTrashHint(classes)) {
+        recordClear(cell, afterDigOrder)
+        return
+      }
+      events.value = [
+        ...events.value,
+        {
+          type: 'set',
+          cell,
+          classes: normalized,
+          afterDigOrder,
+          seq: nextSeq(),
+          at: Date.now(),
+        },
+      ]
+    }
+
+    function recordClear (cell, afterDigOrder) {
+      events.value = [
+        ...events.value,
+        {
+          type: 'clear',
+          cell,
+          afterDigOrder,
+          seq: nextSeq(),
+          at: Date.now(),
+        },
+      ]
+    }
+
+    function recordClearAll (afterDigOrder) {
+      const indices = new Set(
+        events.value
+          .filter((e) => e.type === 'set')
+          .map((e) => e.cell)
+      )
+      const clears = [...indices].map((cell) => ({
+        type: 'clear',
+        cell,
+        afterDigOrder,
+        seq: nextSeq(),
+        at: Date.now(),
+      }))
+      if (clears.length) {
+        events.value = [...events.value, ...clears]
+      }
+    }
+
+    function mergeServerEvents (serverEvents) {
+      if (!Array.isArray(serverEvents) || !serverEvents.length) return
+      const bySeq = new Map(events.value.map((e) => [e.seq, e]))
+      for (const e of serverEvents) {
+        if (e?.seq != null) bySeq.set(e.seq, e)
+      }
+      const merged = [...bySeq.values()].sort((a, b) => a.seq - b.seq)
+      events.value = merged
+      seqCounter = Math.max(seqCounter, ...merged.map((e) => e.seq || 0))
+    }
+
+    /**
+     * Marks visible at replay step k (for future replay UI).
+     * @param {number} stepOrder
+     */
+    function getMarksAtStep (stepOrder) {
+      const active = {}
+      const sorted = [...events.value].sort((a, b) => a.seq - b.seq)
+      for (const e of sorted) {
+        if (e.afterDigOrder > stepOrder) continue
+        if (e.type === 'set') {
+          active[e.cell] = e.classes
+        } else if (e.type === 'clear') {
+          delete active[e.cell]
+        }
+      }
+      return active
+    }
+
+    instances.set(key, {
+      events,
+      recordSet,
+      recordClear,
+      recordClearAll,
+      mergeServerEvents,
+      getMarksAtStep,
+      nextSeq,
+    })
+  }
+
+  return instances.get(key)
+}
+
+export function getMarkEventsSnapshot (landId) {
+  const j = useMarkJournal(landId)
+  return [...(j.events.value || [])]
+}

--- a/src/services/digDayApiService.js
+++ b/src/services/digDayApiService.js
@@ -1,0 +1,43 @@
+const API_BASE = '/api/dig-day'
+
+/**
+ * @param {string} landId
+ * @param {string} utcDate
+ */
+export async function fetchDigDay (landId, utcDate) {
+  const params = new URLSearchParams({ landId: String(landId), utcDate })
+  const res = await fetch(`${API_BASE}?${params}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  })
+
+  const data = await res.json().catch(() => null)
+
+  if (res.status === 404) {
+    return data
+  }
+
+  if (!res.ok) {
+    throw new Error(data?.error || `Failed to load dig day (${res.status})`)
+  }
+
+  return data
+}
+
+/**
+ * @param {object} payload
+ */
+export async function saveDigDay (payload) {
+  const res = await fetch(API_BASE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.error || `Failed to save dig day (${res.status})`)
+  }
+
+  return res.json()
+}

--- a/src/utils/buildDigTimeline.js
+++ b/src/utils/buildDigTimeline.js
@@ -1,0 +1,97 @@
+/** @typedef {{ x: number, y: number, items?: Record<string, number>, tool?: string, dugAt?: number }} DigTile */
+/** @typedef {{ order: number, dugAt: number, tiles: DigTile[] }} DigStep */
+
+export function getTodayUTC () {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/**
+ * Group raw digging.grid entries by dugAt (Sand Drill = one step).
+ * @param {unknown[]} rawGrid
+ * @returns {{ dugAt: number, tiles: DigTile[] }[]}
+ */
+export function groupDigEntries (rawGrid) {
+  if (!Array.isArray(rawGrid)) return []
+
+  return rawGrid.map((entry) => {
+    if (Array.isArray(entry)) {
+      return { dugAt: entry[0]?.dugAt || 0, tiles: entry }
+    }
+    return { dugAt: entry.dugAt || 0, tiles: [entry] }
+  })
+}
+
+/**
+ * Ordered dig steps for replay and mark timing.
+ * @param {unknown[]} rawGrid
+ * @returns {DigStep[]}
+ */
+export function buildDigTimeline (rawGrid) {
+  const entries = groupDigEntries(rawGrid)
+  entries.sort((a, b) => a.dugAt - b.dugAt)
+
+  return entries.map((entry, index) => ({
+    order: index + 1,
+    dugAt: entry.dugAt,
+    tiles: entry.tiles.map((t) => ({
+      x: t.x,
+      y: t.y,
+      items: t.items ? { ...t.items } : {},
+      tool: t.tool,
+    })),
+  }))
+}
+
+/**
+ * Number of completed dig groups (for mark journal afterDigOrder).
+ * @param {unknown[]} rawGrid
+ */
+export function getCurrentDigOrder (rawGrid) {
+  return buildDigTimeline(rawGrid).length
+}
+
+/**
+ * 1D tile index → 1-based dig order (for order badges).
+ * @param {unknown[]} rawGrid
+ * @param {number} gridSize
+ */
+export function buildTreasureOrderMap (rawGrid, gridSize = 10) {
+  const total = gridSize * gridSize
+  const map = Array.from({ length: total }, () => null)
+  const steps = buildDigTimeline(rawGrid)
+
+  for (const step of steps) {
+    for (const { x, y } of step.tiles) {
+      const idx = y * gridSize + x
+      if (idx >= 0 && idx < total) {
+        map[idx] = step.order
+      }
+    }
+  }
+
+  return map
+}
+
+/**
+ * Minimal stats for dig-day snapshot.
+ * @param {DigStep[]} digs
+ */
+export function buildDigStats (digs) {
+  let treasureCount = 0
+
+  for (const step of digs) {
+    for (const tile of step.tiles) {
+      if (!tile.items) continue
+      for (const [name, count] of Object.entries(tile.items)) {
+        if (name !== 'Crab' && name !== 'Sand') {
+          treasureCount += Number(count) || 0
+        }
+      }
+    }
+  }
+
+  return {
+    totalDigs: digs.length,
+    treasureCount,
+  }
+}

--- a/src/views/Digging.vue
+++ b/src/views/Digging.vue
@@ -10,6 +10,8 @@
           <DigToolSection
             v-model:showTreasureOrder="showTreasureOrder"
             v-model:hideLandIdInUrl="hideLandIdInUrl"
+            :dig-day-sync-status="digDaySyncStatus"
+            :dig-day-updated-at="digDayUpdatedAt"
           />
 
           <!-- Pass the toggle and map down into Grid -->
@@ -46,6 +48,8 @@ import { useLandData }    from '@/composables/useLandData'
 import { useGridManager } from '@/composables/useGridManager'
 import { useLandSync } from '@/composables/useLandSync'
 import { usePracticePatterns } from '@/composables/usePracticePatterns.js'
+import { useDigDayStore } from '@/composables/useDigDayStore.js'
+import { buildTreasureOrderMap } from '@/utils/buildDigTimeline.js'
 
 // 1) landId and persistent toggle
 const route = useRoute()
@@ -61,6 +65,12 @@ const hideLandIdInUrl = useLocalStorage(
 const grid = useGridManager(landId)
 const defaults = { visitedFarmState: { inventory: {}, desert: { digging: { grid: [] } } } }
 const { desert } = useLandData(defaults)
+
+const { syncStatus: digDaySyncStatus, lastUpdatedAt: digDayUpdatedAt } = useDigDayStore(
+  landId,
+  desert
+)
+
 watch(
   () => desert.value.digging?.grid,
   rawGrid => {
@@ -72,46 +82,13 @@ watch(
   { immediate: true }
 )
 
-// ── 4) Build a 1D map (tileIndex → 1-based treasure order)
-/**
- * Updated treasureOrderMap:
- * 1. Flattens any nested arrays inside `digging.grid`.
- * 2. Sorts all digs by `dugAt` (timestamp) so ordering is strictly chronological.
- * 3. Builds a map of length `total` that assigns each (x,y) cell its "dig order index".
- */
- const treasureOrderMap = computed(() => {
-  const tilesArray = grid.tiles.value;
-  const total = tilesArray.length;
-  const map = Array.from({ length: total }, () => null);
-
-  const rawGrid = desert.value.digging?.grid || [];
-
-  // Prepare entries with their unified dugAt and grouped tiles
-  const entries = rawGrid.map((entry) => {
-    if (Array.isArray(entry)) {
-      return { dugAt: entry[0]?.dugAt || 0, tiles: entry };
-    } else {
-      return { dugAt: entry.dugAt, tiles: [entry] };
-    }
-  });
-
-  // Sort entries by dugAt timestamp
-  entries.sort((a, b) => a.dugAt - b.dugAt);
-
-  // Assign order index (shared for grouped digs)
-  entries.forEach((entry, orderIndex) => {
-    const digNumber = orderIndex + 1;
-    entry.tiles.forEach(({ x, y }) => {
-      const size = Math.sqrt(total);
-      const idx = y * size + x;
-      if (Number.isInteger(idx) && idx >= 0 && idx < total) {
-        map[idx] = digNumber;
-      }
-    });
-  });
-
-  return map;
-});
+const treasureOrderMap = computed(() => {
+  const total = grid.tiles.value.length
+  if (!total) return []
+  const gridSize = Math.sqrt(total)
+  const rawGrid = desert.value.digging?.grid || []
+  return buildTreasureOrderMap(rawGrid, gridSize)
+})
 
 
 
@@ -126,20 +103,16 @@ onMounted(async () => {
     console.warn('Practice patterns refresh failed:', err)
   }
 
-  console.log("App mounted, checking landData for stale visitedFarmState...")
-  const landId = route.params.landId
+  const routeLandId = route.params.landId
   const today = new Date().toISOString().slice(0, 10)
 
-  if (landId) {
-    const raw = JSON.parse(localStorage.getItem(`landData_${landId}`) || '{}')
+  if (routeLandId) {
+    const raw = JSON.parse(localStorage.getItem(`landData_${routeLandId}`) || '{}')
     const isStale = raw?.date !== today || !raw?.visitedFarmState
-    console.log("Checking landData for ID:", raw?.date , "Stale:", raw?.visitedFarmState)
     if (isStale) {
-      const { reloadFromServer } = useLandSync({ landId })
-      reloadFromServer({ landId })
+      const { reloadFromServer } = useLandSync({ landId: routeLandId })
+      reloadFromServer({ landId: routeLandId })
     }
-  }else {
-    console.log("No landId provided, skipping stale check.")
   }
 })
 </script>

--- a/src/views/PracticeDigging.vue
+++ b/src/views/PracticeDigging.vue
@@ -5,6 +5,10 @@
     >
       <div class="card-body [@media(max-width:639px)]:px-3 [@media(max-width:639px)]:pt-1">
 
+        <p class="text-[0.65rem] text-base-content/60 text-center m-0 mb-2">
+          Unofficial training simulator — no in-game rewards. Not affiliated with Sunflower Land.
+        </p>
+
         <!-- Header row -->
         <div class="flex items-center justify-between gap-2 flex-wrap">
           <h2 class="card-title text-sm sm:text-base">


### PR DESCRIPTION
Store per-land UTC snapshots (digs, patterns, timed mark events), sync from the digging UI, and document blob retrieval for replay groundwork.