### PR TITLE
Use seven patterns per random practice round.

### DIFF
--- a/src/composables/usePracticeEngine.js
+++ b/src/composables/usePracticeEngine.js
@@ -2,7 +2,7 @@ import { ref, computed } from 'vue'
 import { DIGGING_FORMATIONS } from '@/data/game/diggingFormations.js'
 
 const GRID_SIZE = 10
-const PRACTICE_ROUND_LIMIT = 5
+const PRACTICE_ROUND_LIMIT = 7
 const MAX_ARTEFACT_PATTERNS_PER_ROUND = 3
 
 function shuffle(values) {


### PR DESCRIPTION
Match in-game daily treasure count so random practice rounds feel closer to live digging.