### PR TITLE
Release: community/farms API, hub auth, and beta features

### DIFF
--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -27,6 +27,16 @@ Old data may still be in Netlify Blobs `dig-day-snapshots`. Import with `sfl-dig
 
 Daily pattern cache in store `practice-daily-patterns`. See `_practiceDailyStore.cjs`.
 
+## Sunflower Land proxy (`sfl-api`)
+
+Proxies `/.netlify/functions/sfl-api/*` → `api.sunflower-land.com` (or `api-dev` when the client sends `x-sfl-api-env: test`).
+
+Structured logs go to **Netlify function logs** (Site → Functions → sfl-api → Logs). Each line looks like:
+
+`sfl-api { env, path, landId, status, cache: 'hit' | 'miss' }`
+
+Only HTTP 200 responses are cached in-memory for 60s. `/visit/*` often returns 401 for third-party tools — the app uses `/community/farms/*` instead.
+
 ## Admin UI (`/admin`)
 
 Password-protected blob browser. Set `ADMIN_PASSWORD` in Netlify env (or `.env` for `netlify dev`), then open `/admin` on the site.

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -32,6 +32,14 @@ const corsHeaders = {
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
 }
 
+function landIdFromPath (apiPath) {
+  return apiPath.match(/\/(\d+)\/?$/)?.[1] || null
+}
+
+function logSflApi (fields) {
+  console.log('sfl-api', fields)
+}
+
 function getCachedResponse (cacheKey) {
   const entry = responseCache.get(cacheKey)
   if (!entry) return null
@@ -66,11 +74,12 @@ exports.handler = async (event) => {
   const { env, apiKey, origin } = resolveApiTarget(event)
   const { path } = event
   const apiPath = path.replace('/.netlify/functions/sfl-api', '')
+  const landId = landIdFromPath(apiPath)
   const cacheKey = `${env}:${apiPath}`
 
   if (!apiKey) {
     const keyName = env === 'test' ? 'SFL_API_KEY_DEV' : 'SFL_API_KEY'
-    console.log('sfl-api', { env, path: apiPath, status: 500, reason: 'missing_api_key' })
+    logSflApi({ env, path: apiPath, landId, status: 500, reason: 'missing_api_key' })
     return {
       statusCode: 500,
       headers: corsHeaders,
@@ -80,7 +89,7 @@ exports.handler = async (event) => {
 
   const cached = getCachedResponse(cacheKey)
   if (cached) {
-    console.log('sfl-api', { env, path: apiPath, status: cached.statusCode, cache: 'hit' })
+    logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
       statusCode: cached.statusCode,
       headers: corsHeaders,
@@ -105,7 +114,7 @@ exports.handler = async (event) => {
       try {
         data = JSON.parse(text)
       } catch (parseError) {
-        console.log('sfl-api', { env, path: apiPath, status: 502, reason: 'invalid_json' })
+        logSflApi({ env, path: apiPath, landId, status: 502, reason: 'invalid_json' })
         console.error('API JSON parse error:', parseError.message, 'status:', response.status)
         return {
           statusCode: 502,
@@ -120,7 +129,7 @@ exports.handler = async (event) => {
       setCachedResponse(cacheKey, response.status, body)
     }
 
-    console.log('sfl-api', { env, path: apiPath, status: response.status, cache: 'miss' })
+    logSflApi({ env, path: apiPath, landId, status: response.status, cache: 'miss' })
 
     return {
       statusCode: response.status,
@@ -128,7 +137,7 @@ exports.handler = async (event) => {
       body,
     }
   } catch (error) {
-    console.log('sfl-api', { env, path: apiPath, status: 500, reason: 'fetch_error' })
+    logSflApi({ env, path: apiPath, landId, status: 500, reason: 'fetch_error' })
     console.error('API Error:', error)
     return {
       statusCode: 500,

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -73,7 +73,11 @@ exports.handler = async (event) => {
 
   const { env, apiKey, origin } = resolveApiTarget(event)
   const { path } = event
-  const apiPath = path.replace('/.netlify/functions/sfl-api', '')
+  let apiPath = path.replace('/.netlify/functions/sfl-api', '')
+  const legacyVisit = apiPath.startsWith('/visit/')
+  if (legacyVisit) {
+    apiPath = apiPath.replace(/^\/visit\//, '/community/farms/')
+  }
   const landId = landIdFromPath(apiPath)
   const cacheKey = `${env}:${apiPath}`
 
@@ -129,7 +133,14 @@ exports.handler = async (event) => {
       setCachedResponse(cacheKey, response.status, body)
     }
 
-    logSflApi({ env, path: apiPath, landId, status: response.status, cache: 'miss' })
+    logSflApi({
+      env,
+      path: apiPath,
+      landId,
+      status: response.status,
+      cache: 'miss',
+      ...(legacyVisit ? { legacyVisit: true } : {}),
+    })
 
     return {
       statusCode: response.status,

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -20,8 +20,10 @@ export const API_ENVIRONMENTS = {
 
 export const API_CONFIG = {
   ENDPOINTS: {
-    primary: '/.netlify/functions/sfl-api/visit/',
-    backup: '/.netlify/functions/sfl-api/community/farms/',
+    /** Public community snapshot — preferred for third-party tools. */
+    primary: '/.netlify/functions/sfl-api/community/farms/',
+    /** Visit endpoint — often 401 for non-owner farms; kept as fallback only. */
+    backup: '/.netlify/functions/sfl-api/visit/',
   },
 }
 

--- a/src/services/landApiService.js
+++ b/src/services/landApiService.js
@@ -1,70 +1,62 @@
-import { API_CONFIG, getApiHeaders, isTestApiEnvironment } from '@/config/api.js'
+import { API_CONFIG, isTestApiEnvironment } from '@/config/api.js'
 
-// Normalize response format to match primary API structure
-function normalizeApiResponse (data, apiType = 'backup') {
-  if (apiType === 'primary') {
-    // Primary API: {visitedFarmState: {gameObject}}
+function normalizeApiResponse (data) {
+  if (data.farm) {
+    return { visitedFarmState: data.farm }
+  }
+  if (data.visitedFarmState) {
     return data
   }
-  if (apiType === 'backup') {
-    // Backup API: {farm: {gameObject}} -> normalize to {visitedFarmState: {gameObject}}
-    if (data.farm) {
-      return {
-        visitedFarmState: data.farm,
-      }
-    }
-  }
   return data
+}
+
+function apiHeadersForEnv (env) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (env === 'test') {
+    headers['x-sfl-api-env'] = 'test'
+  }
+  return headers
 }
 
 function landNotFoundError () {
   return new Error(
     isTestApiEnvironment()
       ? 'Land not found on test server. Check the land ID or switch to production API.'
-      : 'Land not found. If this is a testnet farm, enable test server mode or add ?testnet to the URL.',
+      : 'Land not found. If this is a testnet farm, add ?testnet to the URL.',
   )
+}
+
+async function fetchCommunityFarm (landId, env) {
+  return fetch(`${API_CONFIG.ENDPOINTS.primary}${landId}`, {
+    headers: apiHeadersForEnv(env),
+  })
 }
 
 export async function fetchLandDataFromServer (landId) {
   if (!landId) throw new Error('landId is required')
 
+  const preferred = isTestApiEnvironment() ? 'test' : 'production'
+  const envs = preferred === 'test' ? ['test', 'production'] : ['production', 'test']
+
   try {
-    const response = await fetch(`${API_CONFIG.ENDPOINTS.primary}${landId}`, {
-      headers: getApiHeaders(),
-    })
+    for (const env of envs) {
+      const response = await fetchCommunityFarm(landId, env)
 
-    if (response.ok) {
-      const data = await response.json()
-      return normalizeApiResponse(data, 'primary')
-    }
-
-    if (response.status === 404) {
-      const backupResponse = await fetch(`${API_CONFIG.ENDPOINTS.backup}${landId}`, {
-        headers: getApiHeaders(),
-      })
-
-      if (backupResponse.ok) {
-        const data = await backupResponse.json()
-        return normalizeApiResponse(data, 'backup')
+      if (response.ok) {
+        const data = await response.json()
+        return normalizeApiResponse(data)
       }
 
-      if (backupResponse.status === 404) {
-        throw landNotFoundError()
-      }
-
-      if (backupResponse.status === 429) {
+      if (response.status === 429) {
         throw new Error('You are sending requests too quickly. Please wait a moment before trying again.')
       }
 
-      throw new Error('Failed to fetch land data from backup API.')
+      if (response.status !== 404) {
+        throw new Error(`Failed to fetch land data (${response.status}).`)
+      }
     }
 
-    if (response.status === 429) {
-      throw new Error('You are sending requests too quickly. Please wait a moment before trying again.')
-    }
-
-    throw new Error('Failed to fetch land data.')
-
+    throw landNotFoundError()
   } catch (error) {
     if (error.message.includes('fetch')) {
       throw new Error('Network error. Please check your connection and try again.')

--- a/src/utils/landRoutes.js
+++ b/src/utils/landRoutes.js
@@ -3,7 +3,11 @@ import {
   isTestApiEnvironment,
   setApiEnvironment,
 } from '@/config/api.js'
-import { hasTestnetQuery, TESTNET_QUERY, withTestnetQuery } from '@/utils/testnet.js'
+import {
+  hasTestnetQuery,
+  TESTNET_QUERY,
+  withTestnetQuery,
+} from '@/utils/testnet.js'
 
 export { TESTNET_QUERY, hasTestnetQuery, withTestnetQuery }
 


### PR DESCRIPTION
## Summary
- Switch land loading to Sunflower Land `community/farms` instead of `/visit/` (401 for third-party tools), with prod/test fallback and legacy `/visit/*` rewrite in `sfl-api`
- Add structured `sfl-api` function logging + 60s in-memory cache for 200 responses
- Includes broader `development` work: hub auth, dig-day sync, account/saved lands, ProjectMate feedback, practice runs, and admin tooling

## Test plan
- [ ] Load a mainnet land on beta — network shows `/community/farms/{id}` returning 200
- [ ] Load a testnet land with `?testnet` — data loads from api-dev
- [ ] Hard-refresh after deploy — no bare `/visit/` 401s (or logs show `legacyVisit: true` → 200)
- [ ] Dig-day GET 404 still returns empty snapshot JSON (expected when nothing saved)
- [ ] Smoke test auth, practice, and digging flows on beta