### PR TITLE
fix: bypass sfl-api cache on Refresh Data and sync development to master

### DIFF
--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -35,7 +35,7 @@ Structured logs go to **Netlify function logs** (Site → Functions → sfl-api 
 
 `sfl-api { env, path, landId, status, cache: 'hit' | 'miss' }`
 
-Only HTTP 200 responses are cached in-memory for 60s. `/visit/*` often returns 401 for third-party tools — the app uses `/community/farms/*` instead.
+Only HTTP 200 responses are cached in-memory for 60s. Send `x-sfl-bypass-cache: 1` (or `?bypassCache=1`) to skip the cache — the app does this on every land sync / Refresh Data click. `/visit/*` often returns 401 for third-party tools — the app uses `/community/farms/*` instead.
 
 ## Admin UI (`/admin`)
 

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -28,8 +28,21 @@ function resolveApiTarget (event) {
 const corsHeaders = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, x-sfl-api-env',
+  'Access-Control-Allow-Headers': 'Content-Type, x-sfl-api-env, x-sfl-bypass-cache',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
+}
+
+function shouldBypassCache (event) {
+  const headers = event.headers || {}
+  const header =
+    headers['x-sfl-bypass-cache'] ||
+    headers['X-Sfl-Bypass-Cache'] ||
+    Object.entries(headers).find(
+      ([k]) => k.toLowerCase() === 'x-sfl-bypass-cache',
+    )?.[1] ||
+    ''
+  const query = event.queryStringParameters?.bypassCache || ''
+  return header === '1' || query === '1'
 }
 
 function landIdFromPath (apiPath) {
@@ -91,7 +104,9 @@ exports.handler = async (event) => {
     }
   }
 
-  const cached = getCachedResponse(cacheKey)
+  const bypassCache = shouldBypassCache(event)
+
+  const cached = !bypassCache && getCachedResponse(cacheKey)
   if (cached) {
     logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
@@ -138,7 +153,7 @@ exports.handler = async (event) => {
       path: apiPath,
       landId,
       status: response.status,
-      cache: 'miss',
+      cache: bypassCache ? 'bypass' : 'miss',
       ...(legacyVisit ? { legacyVisit: true } : {}),
     })
 

--- a/src/composables/useLandSync.js
+++ b/src/composables/useLandSync.js
@@ -62,7 +62,7 @@ export function useLandSync (opts = {}) {
       isLoading.value = true
 
       try {
-        const fresh = await fetchLandData(targetLandId)
+        const fresh = await fetchLandData(targetLandId, { bypassCache: true })
         lastFetchFailed = false
         landData.value = {
           date: new Date().toISOString().slice(0, 10),

--- a/src/services/landApiService.js
+++ b/src/services/landApiService.js
@@ -26,13 +26,15 @@ function landNotFoundError () {
   )
 }
 
-async function fetchCommunityFarm (landId, env) {
-  return fetch(`${API_CONFIG.ENDPOINTS.primary}${landId}`, {
-    headers: apiHeadersForEnv(env),
-  })
+async function fetchCommunityFarm (landId, env, { bypassCache = false } = {}) {
+  const headers = apiHeadersForEnv(env)
+  if (bypassCache) {
+    headers['x-sfl-bypass-cache'] = '1'
+  }
+  return fetch(`${API_CONFIG.ENDPOINTS.primary}${landId}`, { headers })
 }
 
-export async function fetchLandDataFromServer (landId) {
+export async function fetchLandDataFromServer (landId, { bypassCache = false } = {}) {
   if (!landId) throw new Error('landId is required')
 
   const preferred = isTestApiEnvironment() ? 'test' : 'production'
@@ -40,7 +42,7 @@ export async function fetchLandDataFromServer (landId) {
 
   try {
     for (const env of envs) {
-      const response = await fetchCommunityFarm(landId, env)
+      const response = await fetchCommunityFarm(landId, env, { bypassCache })
 
       if (response.ok) {
         const data = await response.json()

--- a/src/services/landSyncService.js
+++ b/src/services/landSyncService.js
@@ -3,11 +3,11 @@ import { fetchLandDataFromServer } from '@/services/landApiService'
 /**
  * Pure fetch; doesn’t touch localStorage or refs.
  */
-export async function fetchLandData (landId) {
+export async function fetchLandData (landId, { bypassCache = false } = {}) {
   if (!landId) throw new Error('landId is required')
 
   try {
-    return await fetchLandDataFromServer(landId)
+    return await fetchLandDataFromServer(landId, { bypassCache })
   } catch (err) {
     // Re-throw with specific 429 message if matched
     if (err.message.includes('too quickly')) {


### PR DESCRIPTION
## Summary
- Fix Refresh Data returning stale land snapshots by bypassing the 60s `sfl-api` proxy cache on every land sync (`x-sfl-bypass-cache: 1`).
- Merge latest `development` work into `master`, including community/farms API routing, dig replay, practice mode, hub auth, account/saved lands, and related Netlify function improvements.

## Test plan
- [x] Skipped per request — deploy and verify Refresh Data on beta after merge.