### PR TITLE
Keep Ko-fi support in site footer only and trim duplicate links.

### DIFF
--- a/src/components/EndSection.vue
+++ b/src/components/EndSection.vue
@@ -3,43 +3,13 @@
   <section class="card bg-base-200 shadow-md p-4 text-sm space-y-4">
     <div class="card-body space-y-2">
       <DiggingAssistantLinks />
-
-      <div class="pt-4 border-t border-base-300">
-        <h4 class="text-lg font-semibold">☕ Support d1g.uk</h4>
-        <p class="text-sm text-base-content/80">
-          Free forever. Optional tips help pay hosting.
-        </p>
-        <a
-          :href="KOFI_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="btn btn-primary btn-sm mt-2"
-        >
-          Support on Ko-fi
-        </a>
-      </div>
-
       <div class="pt-4 border-t border-base-300">
         <h4 class="text-lg font-semibold">🚀 Want to contribute?</h4>
         <p class="text-sm">
           Fork the repo on GitHub:<br />
           <a href="https://github.com/jovylle/sfl-crab" class="link link-secondary">github.com/jovylle/sfl-crab</a><br/>
-          Create a branch, make your changes, and open a Pull Request.<br />
-          To report bugs or request features, please open an issue:<br />
-          <a href="https://github.com/jovylle/sfl-crab/issues" class="link link-secondary">github.com/jovylle/sfl-crab/issues</a><br />
+          Create a branch, make your changes, and open a Pull Request.
         </p>
-      </div>
-
-      <div class="pt-4 border-t border-base-300">
-        <h4 class="text-lg font-semibold">💬 Send feedback, suggestions, or bug reports:</h4>
-        <a
-          href="https://forms.gle/zJayANHdjJ2EQvyB9"
-          target="_blank"
-          rel="noopener"
-          class="btn btn-link btn-sm mt-2"
-        >
-          Feedback Form
-        </a>
       </div>
     </div>
   </section>
@@ -47,5 +17,4 @@
 
 <script setup>
 import DiggingAssistantLinks from '@/components/DiggingAssistantLinks.vue'
-import { KOFI_URL } from '@/config/support.js'
 </script>

--- a/src/components/MainDrawer.vue
+++ b/src/components/MainDrawer.vue
@@ -43,7 +43,7 @@
           </template>
           <button
             v-if="isProjectMateReady"
-            :class="kofiUrl ? 'btn btn-outline btn-block' : 'btn btn-primary btn-block'"
+            class="btn btn-primary btn-block"
             @click="openProjectMate"
           >
             Open Help
@@ -72,7 +72,6 @@ import AccountSection from '@/components/AccountSection.vue'
 import FeedbackModal from '@/components/FeedbackModal.vue'
 import { resolveLandRoute } from '@/utils/landRoutes.js'
 import { useApiEnvironment } from '@/composables/useApiEnvironment.js'
-import { KOFI_URL } from '@/config/support.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -80,9 +79,8 @@ const { isTestServer } = useApiEnvironment()
 const isProjectMateReady = ref(false)
 const feedbackOpen = ref(false)
 const hasFeedbackForm = Boolean(import.meta.env.VITE_PROJECTMATE_WEB3FORMS_KEY)
-const kofiUrl = KOFI_URL
 const showSupportSection = computed(
-  () => isProjectMateReady.value || hasFeedbackForm || Boolean(kofiUrl),
+  () => isProjectMateReady.value || hasFeedbackForm,
 )
 
 function syncProjectMateReady () {

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -19,15 +19,6 @@
       >
         GitHub
       </a>
-      <span class="text-base-content/30" aria-hidden="true">·</span>
-      <a
-        href="https://github.com/jovylle/sfl-crab/issues"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="link link-hover"
-      >
-        Feedback
-      </a>
     </div>
     <p v-if="buildHash" class="mt-2 text-[0.6rem] text-base-content/30 font-mono">
       build {{ buildHash }}


### PR DESCRIPTION
Remove repeated tip, feedback, and issues links from the drawer and EndSection while keeping mirror and contribute info.