### PR TITLE
feat: preserve landId across Practice tab + acknowledge ?land= on dig…

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,8 +16,17 @@ const router = createRouter({
   routes,
 })
 
+const LAND_QUERY_PROMOTE = { GuestDigging: 'Digging' } // extend later if needed
 router.beforeEach((to) => {
   syncApiEnvFromRoute(to)
+  if (to.params.landId) return                       // already has one; avoids redirect loop
+  const target = LAND_QUERY_PROMOTE[to.name]
+  if (!target) return
+  const land = String(to.query.land || '').trim()
+  if (!/^\d+$/.test(land)) return
+  const query = { ...to.query }
+  delete query.land
+  return { name: target, params: { landId: land }, query, hash: to.hash }
 })
 
 export default router

--- a/src/router/routes/digging.js
+++ b/src/router/routes/digging.js
@@ -6,7 +6,7 @@ import PracticeDigging from '@/views/PracticeDigging.vue'
 
 /** @type {import('vue-router').RouteRecordRaw[]} */
 export const diggingRoutes = [
-  { path: '/', name: 'Home', redirect: '/digging' },
+  { path: '/', name: 'Home', redirect: to => ({ path: '/digging', query: to.query, hash: to.hash }) },
   {
     path: '/digging',
     name: 'GuestDigging',

--- a/src/views/PracticeDigging.vue
+++ b/src/views/PracticeDigging.vue
@@ -234,6 +234,7 @@ import { getTodayUTC } from '@/utils/buildDigTimeline.js'
 import { buildPracticeDigTimeline } from '@/utils/buildPracticeDigTimeline.js'
 import { encodeBoard, decodeBoard } from '@/utils/practiceBoardCode.js'
 import { PRACTICE_IN_PROGRESS_KEY } from '@/constants/storageKeys.js'
+import { resolveLandRoute } from '@/utils/landRoutes.js'
 
 const ALL_FORMATION_KEYS = Object.keys(DIGGING_FORMATIONS)
 const IN_PROGRESS_VERSION = 1
@@ -444,7 +445,10 @@ watch(formationPlacements, placements => {
   try {
     const code = encodeBoard(placements)
     if (route.query.board === code) return
-    router.replace({ name: 'Practice', query: { board: code } })
+    const landId = route.params.landId
+    router.replace(
+      resolveLandRoute(landId ? 'practice' : 'practiceNoId', { landId, query: { board: code } }),
+    )
   } catch {
     /* encoding/navigation failed — leave the URL as-is */
   }
@@ -454,7 +458,9 @@ async function copyBoardLink () {
   if (!formationPlacements.value.length) return
   try {
     const code = encodeBoard(formationPlacements.value)
-    const href = location.origin + router.resolve({ name: 'Practice', query: { board: code } }).href
+    const landId = route.params.landId
+    const to = resolveLandRoute(landId ? 'practice' : 'practiceNoId', { landId, query: { board: code } })
+    const href = location.origin + router.resolve(to).href
     await navigator.clipboard.writeText(href)
     boardLinkCopied.value = true
     if (boardLinkCopiedTimerId !== null) clearTimeout(boardLinkCopiedTimerId)


### PR DESCRIPTION
…ging/home

- PracticeDigging board-sync watcher & copyBoardLink now use resolveLandRoute so /1/practice keeps its /1/ prefix (was dropped to /practice), which also makes the Digging tab return to /1/digging and shared links keep land context.
- Home redirect ('/') now forwards query+hash so /?land=1 survives.
- router.beforeEach promotes numeric ?land= into the path param on the landless digging route (GuestDigging→Digging), idempotent and testnet-preserving.