### PR TITLE
fix: don't auto-flag long land IDs as testnet in Saved Lands list

### DIFF
--- a/src/views/Account.vue
+++ b/src/views/Account.vue
@@ -110,7 +110,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { useHubSession } from '@/composables/useHubSession.js'
 import { isTestApiEnvironment } from '@/config/api.js'
 import { resolveLandRoute } from '@/utils/landRoutes.js'
-import { isTestnetLandId } from '@/utils/testnet.js'
 import {
   fetchProfile,
   fetchSavedLands,
@@ -206,7 +205,7 @@ const displayLands = computed(() => (
       return {
         ...item,
         ...decoded,
-        isTestnet: decoded.isTestnet || isTestnetLandId(decoded.landId),
+        isTestnet: decoded.isTestnet,
       }
     })
     .filter((item) => item.landId)


### PR DESCRIPTION
Land IDs with 13+ digits were being treated as testnet due to the isTestnetLandId heuristic, causing non-testnet saves like 4485248732423974 to always navigate to the testnet URL. decodeStoredLandId already handles all explicit testnet encodings (?testnet suffix and legacy formats), so the extra heuristic was only producing false positives.