### PR TITLE
fix: whole-pattern-guarantee misses shapes proven only via Pass 1 anc…

### DIFF
--- a/scripts/debug-solver.js
+++ b/scripts/debug-solver.js
@@ -123,7 +123,7 @@ function printBoard (tiles, guaranteed, guaranteedSlugs) {
 
 function runSingle (filePath) {
   const { tiles, patternKeys } = loadSnapshot(filePath)
-  const { guaranteed, guaranteedSlugs, guaranteedFormationKeys } = solveTreasures(tiles, patternKeys, GRID_SIZE)
+  const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(tiles, patternKeys, GRID_SIZE)
 
   console.log(`\n=== ${filePath} ===`)
   console.log(`Patterns on board: ${patternKeys.length ? patternKeys.join(', ') : '(none)'}\n`)
@@ -139,8 +139,10 @@ function runSingle (filePath) {
     }
   }
 
-  console.log(`\nWhole-pattern-guaranteed (${guaranteedFormationKeys.size}):`)
-  console.log(guaranteedFormationKeys.size ? `  ${[...guaranteedFormationKeys].join(', ')}` : '  (none)')
+  console.log(`\nWhole-pattern-guaranteed (${guaranteedFormationCounts.size}):`)
+  console.log(guaranteedFormationCounts.size
+    ? `  ${[...guaranteedFormationCounts].map(([key, count]) => `${key} (${count})`).join(', ')}`
+    : '  (none)')
 }
 
 function runDiff (earlierPath, laterPath) {

--- a/src/components/PracticePatterns.vue
+++ b/src/components/PracticePatterns.vue
@@ -55,6 +55,7 @@ import { computed, ref, toRef } from 'vue'
 import { DIGGING_FORMATIONS } from '@/data/game/diggingFormations.js'
 import { useReliableAssets } from '@/composables/useReliableAssets.js'
 import { usePredictionEngine } from '@/composables/usePredictionEngine.js'
+import { buildGuaranteedIndexes } from '@/utils/patternPreview.js'
 
 const { getImageSrc } = useReliableAssets()
 
@@ -91,15 +92,18 @@ const solverTiles = computed(() =>
 
 // Second, independent solver instance (PracticeGrid.vue runs its own) — cheap
 // pure/synchronous solve, avoids lifting prediction state into props.
-const { guaranteedFormationKeys } = usePredictionEngine(
+const { guaranteedFormationCounts } = usePredictionEngine(
   solverTiles,
   toRef(props, 'patternKeys'),
   toRef(props, 'showPrediction'),
 )
 
+const guaranteedIndexSet = computed(() =>
+  buildGuaranteedIndexes(props.patternKeys, guaranteedFormationCounts.value),
+)
+
 function isGuaranteed (index) {
-  const key = props.patternKeys[index]
-  return key != null && guaranteedFormationKeys.value.has(key)
+  return guaranteedIndexSet.value.has(index)
 }
 
 function formatKey(key) {

--- a/src/components/TodayPatterns.vue
+++ b/src/components/TodayPatterns.vue
@@ -32,7 +32,7 @@ import { useRoute } from 'vue-router'
 import { useNow } from '@vueuse/core'
 import { useLandData } from '../composables/useLandData'
 import { usePatternMarks } from '@/composables/usePatternMarks.js'
-import { buildServerCompletedIndexes } from '@/utils/patternPreview.js'
+import { buildServerCompletedIndexes, buildGuaranteedIndexes } from '@/utils/patternPreview.js'
 import { useGridManager } from '@/composables/useGridManager'
 import { usePredictionEngine } from '@/composables/usePredictionEngine.js'
 import PatternStrip from '@/components/PatternStrip.vue'
@@ -65,21 +65,15 @@ const completedIndexList = computed(() => [...serverCompletedIndexes.value])
 // dailyPatternKeys (the cached "Today's Treasures" list) can occasionally be
 // stale relative to it (see isPatternDateStale below).
 const { tiles } = useGridManager(landId)
-const { guaranteedFormationKeys } = usePredictionEngine(
+const { guaranteedFormationCounts } = usePredictionEngine(
   tiles,
   authoritativePatternKeys,
   toRef(() => props.showPrediction),
 )
 
-const guaranteedIndexList = computed(() => {
-  const indexes = []
-  patternKeys.value.forEach((key, index) => {
-    if (guaranteedFormationKeys.value.has(key) && !serverCompletedIndexes.value.has(index)) {
-      indexes.push(index)
-    }
-  })
-  return indexes
-})
+const guaranteedIndexList = computed(() => [
+  ...buildGuaranteedIndexes(patternKeys.value, guaranteedFormationCounts.value, serverCompletedIndexes.value),
+])
 
 const now = useNow({ interval: 30000 })
 const currentUtcDate = computed(() => new Date(now.value).toISOString().slice(0, 10))

--- a/src/composables/usePredictionEngine.js
+++ b/src/composables/usePredictionEngine.js
@@ -10,7 +10,7 @@ import { solveTreasures } from '@/utils/treasureSolver.js'
 export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { gridSize = 10, syncRef = null } = {}) {
   const guaranteed = ref(new Set())
   const guaranteedSlugs = ref(new Map())
-  const guaranteedFormationKeys = ref(new Set())
+  const guaranteedFormationCounts = ref(new Map())
 
   const schedule = (typeof window !== 'undefined' && window.requestIdleCallback)
     ? window.requestIdleCallback.bind(window)
@@ -25,7 +25,7 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     const result = solveTreasures(tilesRef.value, patternKeysRef.value, gridSize)
     guaranteed.value = result.guaranteed
     guaranteedSlugs.value = result.guaranteedSlugs
-    guaranteedFormationKeys.value = result.guaranteedFormationKeys
+    guaranteedFormationCounts.value = result.guaranteedFormationCounts
   }
 
   function recompute() {
@@ -34,7 +34,7 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     if (!enabledRef.value) {
       guaranteed.value = new Set()
       guaranteedSlugs.value = new Map()
-      guaranteedFormationKeys.value = new Set()
+      guaranteedFormationCounts.value = new Map()
       return
     }
 
@@ -60,5 +60,5 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     { immediate: true, deep: true }
   )
 
-  return { guaranteed, guaranteedSlugs, guaranteedFormationKeys }
+  return { guaranteed, guaranteedSlugs, guaranteedFormationCounts }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -576,6 +576,7 @@ body {
   color: #111;
   border: 1px solid color-mix(in srgb, var(--color-base-300) 70%, transparent);
   box-shadow: 0 0 0 1px color-mix(in srgb, black 15%, transparent);
+  border-radius: 50%;
 }
 
 .digging-patterns .pattern-thumb {

--- a/src/utils/patternPreview.js
+++ b/src/utils/patternPreview.js
@@ -77,3 +77,28 @@ export function buildServerCompletedIndexes (patternKeys, completedPatternKeys) 
   })
   return indexes
 }
+
+/**
+ * Map guaranteed-instance counts (per formation key) to thumb indexes
+ * (left-to-right), even when a key repeats. Indexes in `excludedIndexes`
+ * (e.g. already server-completed) are skipped and don't consume an allocation.
+ * @param {string[]} patternKeys
+ * @param {Map<string, number>} guaranteedFormationCounts
+ * @param {Set<number>} [excludedIndexes]
+ * @returns {Set<number>}
+ */
+export function buildGuaranteedIndexes(patternKeys, guaranteedFormationCounts, excludedIndexes) {
+  const remaining = new Map()
+  const indexes = new Set()
+  ;(patternKeys || []).forEach((key, index) => {
+    if (excludedIndexes?.has(index)) return
+    const left = remaining.has(key) ? remaining.get(key) : (guaranteedFormationCounts.get(key) ?? 0)
+    if (left > 0) {
+      indexes.add(index)
+      remaining.set(key, left - 1)
+    } else {
+      remaining.set(key, 0)
+    }
+  })
+  return indexes
+}

--- a/src/utils/treasureSolver.js
+++ b/src/utils/treasureSolver.js
@@ -83,12 +83,12 @@ function flattenTile(tile) {
  * @param {(string[]|string)[]} tiles - grid cells of CSS class arrays
  * @param {string[]} patternKeys - formation multiset on the board
  * @param {number} gridSize - default 10
- * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedFormationKeys: Set<string>, partial: boolean }}
+ * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedFormationCounts: Map<string,number>, partial: boolean }}
  */
 export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   const guaranteed = new Set()
   if (!patternKeys?.length) {
-    return { guaranteed, guaranteedSlugs: new Map(), guaranteedFormationKeys: new Set(), partial: false }
+    return { guaranteed, guaranteedSlugs: new Map(), guaranteedFormationCounts: new Map(), partial: false }
   }
 
   // ── Parse revealed state ────────────────────────────────────────────
@@ -268,12 +268,24 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // no new promotable cells.
   const pseudoRevealed = new Set()
 
-  // Keys whose one true instance was pinned by Pass 1's per-anchor reasoning
-  // (a single surviving candidate for a shapeCount(key) === 1 formation is the
-  // same soundness condition used elsewhere to promote pseudo-reveals/mark
-  // cells guaranteed — this just remembers WHICH key produced that proof, so
-  // finalization doesn't have to weaker-rediscover it via full-board fallback).
-  const confirmedInstanceKeys = new Set()
+  // A single surviving candidate for a treasure anchor pins that placement as
+  // the real instance, regardless of whether the shape has 1 or N occurrences
+  // on the board (same soundness argument either way — see Pass 1 below). We
+  // remember WHICH instance was pinned, per key, keyed by a canonical
+  // signature of its cell indices, so finalization can count how many
+  // DISTINCT instances of a duplicated shape are individually proven. A
+  // Set<signature> (not a counter) is required because the same real instance
+  // can be independently re-confirmed by two different anchors within it
+  // (e.g. two plots sharing a name) — deduping by signature avoids
+  // double-counting one instance as two.
+  const confirmedInstances = new Map() // key -> Set<signature>
+
+  const placementSignature = (plots) => [...plots.keys()].sort((a, b) => a - b).join(',')
+
+  const recordConfirmedInstance = (key, plots) => {
+    if (!confirmedInstances.has(key)) confirmedInstances.set(key, new Set())
+    confirmedInstances.get(key).add(placementSignature(plots))
+  }
 
   let iterChanged = true
   while (iterChanged) {
@@ -309,7 +321,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       const candidates = computeCandidates(tIdx, tName)
       if (candidates.length !== 1) continue
       const { key, plots } = candidates[0]
-      if (shapeCount.get(key) === 1) confirmedInstanceKeys.add(key)
+      recordConfirmedInstance(key, plots)
       for (const [idx, name] of plots) {
         if (!revealedTreasureName.has(idx) && !pseudoRevealed.has(idx)) {
           revealedTreasureName.set(idx, name)
@@ -323,8 +335,8 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     for (const [tIdx, tName] of revealedTreasureName) {
       const candidates = computeCandidates(tIdx, tName)
       if (!candidates.length) continue // inconsistent — skip safely
-      if (candidates.length === 1 && shapeCount.get(candidates[0].key) === 1) {
-        confirmedInstanceKeys.add(candidates[0].key)
+      if (candidates.length === 1) {
+        recordConfirmedInstance(candidates[0].key, candidates[0].plots)
       }
       intersectCandidates(candidates.map(c => c.plots))
     }
@@ -381,19 +393,23 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   }
 
   // ── Whole-pattern-guarantee finalization ────────────────────────────
-  // Only single-instance shapes can ever be pinned to one specific placement
-  // (a duplicated shape leaves ambiguity about which instance owns a proven
-  // cell). Against the now-converged revealedTreasureName (including all
-  // pseudo-reveals from the loop above), re-run the same survivor enumeration
-  // one last time: if exactly one legal placement remains, that placement IS
-  // the real instance — every one of its cells is a proven treasure at its
-  // correct relative offset, so the whole formation is guaranteed.
-  const guaranteedFormationKeys = new Set(confirmedInstanceKeys)
+  // For each present key, the count of individually-proven instances is the
+  // number of distinct signatures Pass 1 pinned for it (sound regardless of
+  // shapeCount — two real formation instances can never occupy overlapping
+  // cells, so N distinct confirmed signatures means N real instances are
+  // individually known, full stop). For single-instance shapes, also fold in
+  // the confined-name/full-board enumeration route (e.g. COCKLE/SEAWEED),
+  // bumping the count to 1 if Pass 1's anchor reasoning didn't already catch
+  // it — this preserves the previously-working single-instance path.
+  const guaranteedFormationCounts = new Map()
   for (const key of presentKeys) {
-    if (shapeCount.get(key) !== 1) continue
-    const survivors = enumerateSingleInstanceSurvivors(key)
-    if (survivors.length === 1) guaranteedFormationKeys.add(key)
+    let count = confirmedInstances.get(key)?.size ?? 0
+    if (shapeCount.get(key) === 1 && count === 0) {
+      const survivors = enumerateSingleInstanceSurvivors(key)
+      if (survivors.length === 1) count = 1
+    }
+    if (count > 0) guaranteedFormationCounts.set(key, count)
   }
 
-  return { guaranteed, guaranteedSlugs, guaranteedFormationKeys, partial: false }
+  return { guaranteed, guaranteedSlugs, guaranteedFormationCounts, partial: false }
 }

--- a/src/utils/treasureSolver.js
+++ b/src/utils/treasureSolver.js
@@ -116,9 +116,9 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // Formation shapes present on the board. Dedup by key (one instance is enough
   // for local reasoning), and include every shape so a revealed treasure can be
   // anchored to whichever shape truly owns it.
-  const shapes = [...new Set(patternKeys)]
-    .map(key => DIGGING_FORMATIONS[key])
-    .filter(f => Array.isArray(f) && f.length)
+  const shapeEntries = [...new Set(patternKeys)]
+    .map(key => ({ key, formation: DIGGING_FORMATIONS[key] }))
+    .filter(({ formation }) => Array.isArray(formation) && formation.length)
 
   const inBounds = (x, y) => x >= 0 && x < gridSize && y >= 0 && y < gridSize
 
@@ -268,6 +268,13 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // no new promotable cells.
   const pseudoRevealed = new Set()
 
+  // Keys whose one true instance was pinned by Pass 1's per-anchor reasoning
+  // (a single surviving candidate for a shapeCount(key) === 1 formation is the
+  // same soundness condition used elsewhere to promote pseudo-reveals/mark
+  // cells guaranteed — this just remembers WHICH key produced that proof, so
+  // finalization doesn't have to weaker-rediscover it via full-board fallback).
+  const confirmedInstanceKeys = new Set()
+
   let iterChanged = true
   while (iterChanged) {
     iterChanged = false
@@ -285,13 +292,13 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       const tx = tIdx % gridSize
       const ty = Math.floor(tIdx / gridSize)
       const candidates = []
-      for (const formation of shapes) {
+      for (const { key, formation } of shapeEntries) {
         for (const anchor of formation) {
           if (!namesMatch(anchor.name, tName)) continue
           const ox = tx - anchor.x
           const oy = ty - anchor.y
           const plots = buildPlacement(formation, ox, oy)
-          if (plots) candidates.push(plots)
+          if (plots) candidates.push({ key, plots })
         }
       }
       return candidates
@@ -301,7 +308,9 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     for (const [tIdx, tName] of revealedTreasureName) {
       const candidates = computeCandidates(tIdx, tName)
       if (candidates.length !== 1) continue
-      for (const [idx, name] of candidates[0]) {
+      const { key, plots } = candidates[0]
+      if (shapeCount.get(key) === 1) confirmedInstanceKeys.add(key)
+      for (const [idx, name] of plots) {
         if (!revealedTreasureName.has(idx) && !pseudoRevealed.has(idx)) {
           revealedTreasureName.set(idx, name)
           pseudoRevealed.add(idx)
@@ -314,7 +323,10 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     for (const [tIdx, tName] of revealedTreasureName) {
       const candidates = computeCandidates(tIdx, tName)
       if (!candidates.length) continue // inconsistent — skip safely
-      intersectCandidates(candidates)
+      if (candidates.length === 1 && shapeCount.get(candidates[0].key) === 1) {
+        confirmedInstanceKeys.add(candidates[0].key)
+      }
+      intersectCandidates(candidates.map(c => c.plots))
     }
 
     // ── Pass 2: single-instance forcing ─────────────────────────────────
@@ -376,7 +388,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // one last time: if exactly one legal placement remains, that placement IS
   // the real instance — every one of its cells is a proven treasure at its
   // correct relative offset, so the whole formation is guaranteed.
-  const guaranteedFormationKeys = new Set()
+  const guaranteedFormationKeys = new Set(confirmedInstanceKeys)
   for (const key of presentKeys) {
     if (shapeCount.get(key) !== 1) continue
     const survivors = enumerateSingleInstanceSurvivors(key)

--- a/tests/solver.oracle.test.js
+++ b/tests/solver.oracle.test.js
@@ -147,7 +147,7 @@ function runSoundnessCheck(seeds, numFormations) {
     const board = generateBoard(rng, numFormations)
     if (!board) { skipped++; continue }
 
-    const { guaranteed, guaranteedSlugs, guaranteedFormationKeys } = solveTreasures(board.tiles, board.patternKeys, G)
+    const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(board.tiles, board.patternKeys, G)
 
     for (const idx of guaranteed) {
       if (!board.truth.has(idx)) {
@@ -165,7 +165,7 @@ function runSoundnessCheck(seeds, numFormations) {
     // placement already in `guaranteed`, with a matching name where the solver
     // reports one. This generator only ever picks unique keys, so `keyToPlots`
     // unambiguously identifies "this formation's real placement".
-    for (const key of guaranteedFormationKeys) {
+    for (const key of guaranteedFormationCounts.keys()) {
       const plots = board.keyToPlots.get(key)
       for (const [idx, name] of plots) {
         const label = String.fromCharCode(65 + (idx % G)) + (Math.floor(idx / G) + 1)
@@ -196,7 +196,7 @@ function expectNoFailures({ failures, formationFailures }) {
     const msg = formationFailures.slice(0, 5).map(f =>
       `seed=${f.seed} key=${f.key} cell=${f.label} — ${f.reason}`
     ).join('\n')
-    expect.fail(`${formationFailures.length} guaranteedFormationKeys false positive(s):\n${msg}`)
+    expect.fail(`${formationFailures.length} guaranteedFormationCounts false positive(s):\n${msg}`)
   }
 }
 

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest'
 import { solveTreasures } from '@/utils/treasureSolver.js'
 import { gridArrayToTiles } from '@/utils/gridTileTransform.js'
+import { buildGuaranteedIndexes } from '@/utils/patternPreview.js'
 
 const G = 10
 
@@ -54,7 +55,7 @@ describe('Pass 2 — single-instance confined-name forcing', () => {
     const tiles = makeTiles([
       { x: 4, y: 4, items: { 'Wooden Compass': 1 } },
     ])
-    const { guaranteed, guaranteedSlugs, guaranteedFormationKeys } = solveTreasures(tiles, ['WOODEN_COMPASS'], G)
+    const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(tiles, ['WOODEN_COMPASS'], G)
 
     // Both Wood tiles (x=3,y=4 idx=43 and x=5,y=4 idx=45) must be guaranteed
     expect(guaranteed.has(43)).toBe(true)
@@ -67,7 +68,7 @@ describe('Pass 2 — single-instance confined-name forcing', () => {
 
     // Every cell of this single-instance formation is now pinned — the whole
     // pattern is guaranteed, not just individual cells.
-    expect(guaranteedFormationKeys.has('WOODEN_COMPASS')).toBe(true)
+    expect(guaranteedFormationCounts.has('WOODEN_COMPASS')).toBe(true)
   })
 
   it('does NOT mark the formation whole-pattern-guaranteed when only one of its cells is pinned', () => {
@@ -77,11 +78,11 @@ describe('Pass 2 — single-instance confined-name forcing', () => {
     const tiles = makeTiles([
       { x: 5, y: 5, items: { 'Old Bottle': 1 } },
     ])
-    const { guaranteed, guaranteedFormationKeys } = solveTreasures(tiles, ['OLD_BOTTLE'], G)
+    const { guaranteed, guaranteedFormationCounts } = solveTreasures(tiles, ['OLD_BOTTLE'], G)
 
     expect(guaranteed.has(55)).toBe(true) // the revealed cell itself
     expect(guaranteed.size).toBe(1) // nothing else pinned yet
-    expect(guaranteedFormationKeys.has('OLD_BOTTLE')).toBe(false)
+    expect(guaranteedFormationCounts.has('OLD_BOTTLE')).toBe(false)
   })
 })
 
@@ -175,7 +176,7 @@ describe('Edge cases', () => {
       'HIEROGLYPH', 'HIEROGLYPH', 'COCKLE', 'SEAWEED', 'CLAM_SHELLS',
     ]
     const tiles = gridArrayToTiles(grid, G)
-    const { guaranteed, guaranteedSlugs, guaranteedFormationKeys } = solveTreasures(tiles, patterns, G)
+    const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(tiles, patterns, G)
 
     // Clam Shell cells at (3,8),(4,8),(3,9),(4,9) already revealed — not in guaranteed
     // Seaweed at H9 (idx 78) already revealed — not in guaranteed
@@ -194,25 +195,29 @@ describe('Edge cases', () => {
 
     // CLAM_SHELLS is single-instance and fully revealed (all 4 corners dug) —
     // the whole pattern is guaranteed.
-    expect(guaranteedFormationKeys.has('CLAM_SHELLS')).toBe(true)
+    expect(guaranteedFormationCounts.get('CLAM_SHELLS')).toBe(1)
 
-    // HIEROGLYPH appears TWICE on this board — a duplicate shape can never be
-    // whole-pattern-guaranteed (no way to know which instance a proven cell
-    // belongs to), even though individual Hieroglyph cells are guaranteed above.
-    expect(guaranteedFormationKeys.has('HIEROGLYPH')).toBe(false)
+    // HIEROGLYPH appears TWICE on this board, and BOTH instances are
+    // individually pinned by Pass 1's per-anchor reasoning: the Hieroglyph
+    // dug at E2 (idx 14) forces its Vase cells at E1/F1, and the Hieroglyph
+    // dug at D5 (idx 43) forces its Vase cells at D4/E4 — two distinct,
+    // non-overlapping placements, so both instances are known and the count
+    // is 2 (not gated to "all-or-nothing" — see buildGuaranteedIndexes, which
+    // checkmarks exactly as many of the key's thumbnails as instances proven).
+    expect(guaranteedFormationCounts.get('HIEROGLYPH')).toBe(2)
 
     // COCKLE and SEAWEED are single-instance and fully pinned — guaranteed.
-    expect(guaranteedFormationKeys.has('COCKLE')).toBe(true)
-    expect(guaranteedFormationKeys.has('SEAWEED')).toBe(true)
+    expect(guaranteedFormationCounts.get('COCKLE')).toBe(1)
+    expect(guaranteedFormationCounts.get('SEAWEED')).toBe(1)
 
     // ARTEFACT_TWENTY_TWO/_THREE/_TWENTY are each single-instance shapes whose
     // one true placement is pinned by Pass 1's per-anchor reasoning (shared
     // "Camel Bone" name across all three prevents the full-board fallback from
-    // narrowing to one candidate on its own) — confirmedInstanceKeys should
+    // narrowing to one candidate on its own) — confirmedInstances should
     // still catch them.
-    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY_TWO')).toBe(true)
-    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY_THREE')).toBe(true)
-    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY')).toBe(true)
+    expect(guaranteedFormationCounts.get('ARTEFACT_TWENTY_TWO')).toBe(1)
+    expect(guaranteedFormationCounts.get('ARTEFACT_TWENTY_THREE')).toBe(1)
+    expect(guaranteedFormationCounts.get('ARTEFACT_TWENTY')).toBe(1)
 
     // ── Artefact cascade ─────────────────────────────────────────────────────
     // Phase A of Pass 1 promotes single-candidate anchors immediately:
@@ -239,6 +244,58 @@ describe('Edge cases', () => {
       expect(guaranteed.has(idx), `arte23 bone ${lbl} (idx ${idx})`).toBe(true)
       expect(guaranteedSlugs.get(idx)).toBe('camel_bone')
     }
+  })
+
+  it('known real-world snapshot — land 1405000790165644 partially confirms one of two HIEROGLYPH instances', () => {
+    // Captured 2026-07-16. Same 8-key pattern list as the 4485248732423974
+    // snapshot above, but a different dig layout: only ONE Hieroglyph is dug
+    // (at H4, idx 37), pinning its Vase cells at H3 (idx 27, guaranteed) and
+    // I3 (idx 28, already dug) — the OTHER Hieroglyph instance has no reveals
+    // anywhere near it and stays completely unknown. Confirms the N-of-M
+    // behavior end-to-end: guaranteedFormationCounts.get('HIEROGLYPH') is 1,
+    // not 2, and buildGuaranteedIndexes flags exactly one of the two
+    // HIEROGLYPH thumbnails (not both, not neither).
+    const grid = [
+      { x: 8, y: 7, items: { Crab: 1 } },
+      { x: 2, y: 8, items: { 'Camel Bone': 1 } },
+      { x: 1, y: 7, items: { Crab: 1 } },
+      { x: 3, y: 7, items: { Seaweed: 1 } },
+      { x: 1, y: 9, items: { 'Camel Bone': 1 } },
+      { x: 4, y: 8, items: { Starfish: 1 } },
+      { x: 7, y: 1, items: { Crab: 1 } },
+      { x: 1, y: 2, items: { 'Cockle Shell': 1 } },
+      { x: 3, y: 4, items: { Crab: 1 } },
+      { x: 0, y: 8, items: { Crab: 1 } },
+      { x: 8, y: 2, items: { Vase: 1 } },
+      { x: 7, y: 3, items: { Hieroglyph: 1 } },
+      { x: 7, y: 8, items: { 'Salt Dino Egg': 1 } },
+      { x: 3, y: 1, items: { Sand: 1 } },
+      { x: 4, y: 3, items: { Sand: 1 } },
+      { x: 2, y: 5, items: { 'Clam Shell': 1 } },
+      { x: 8, y: 5, items: { Sand: 1 } },
+      { x: 1, y: 4, items: { 'Clam Shell': 1 } },
+      { x: 5, y: 5, items: { Sand: 1 } },
+      { x: 5, y: 1, items: { 'Camel Bone': 1 } },
+    ]
+    const patterns = [
+      'ARTEFACT_TWENTY_TWO', 'ARTEFACT_TWENTY_THREE', 'ARTEFACT_TWENTY',
+      'HIEROGLYPH', 'HIEROGLYPH', 'COCKLE', 'SEAWEED', 'CLAM_SHELLS',
+    ]
+    const tiles = gridArrayToTiles(grid, G)
+    const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(tiles, patterns, G)
+
+    // H3 = idx 27: the Vase cell forced by the single dug Hieroglyph at H4 (idx 37)
+    expect(guaranteed.has(27)).toBe(true)
+    expect(guaranteedSlugs.get(27)).toBe('vase')
+
+    // Only ONE Hieroglyph instance is pinned — the other has no reveals to anchor on.
+    expect(guaranteedFormationCounts.get('HIEROGLYPH')).toBe(1)
+
+    // buildGuaranteedIndexes should flag exactly one of the two HIEROGLYPH
+    // thumbnails (indexes 3 and 4 in `patterns`), not both.
+    const guaranteedIndexes = buildGuaranteedIndexes(patterns, guaranteedFormationCounts)
+    const hieroglyphFlagged = [3, 4].filter(i => guaranteedIndexes.has(i))
+    expect(hieroglyphFlagged.length).toBe(1)
   })
 
   it('artefact-only — same board, D2 slug unambiguous without other formations', () => {

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -201,6 +201,19 @@ describe('Edge cases', () => {
     // belongs to), even though individual Hieroglyph cells are guaranteed above.
     expect(guaranteedFormationKeys.has('HIEROGLYPH')).toBe(false)
 
+    // COCKLE and SEAWEED are single-instance and fully pinned — guaranteed.
+    expect(guaranteedFormationKeys.has('COCKLE')).toBe(true)
+    expect(guaranteedFormationKeys.has('SEAWEED')).toBe(true)
+
+    // ARTEFACT_TWENTY_TWO/_THREE/_TWENTY are each single-instance shapes whose
+    // one true placement is pinned by Pass 1's per-anchor reasoning (shared
+    // "Camel Bone" name across all three prevents the full-board fallback from
+    // narrowing to one candidate on its own) — confirmedInstanceKeys should
+    // still catch them.
+    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY_TWO')).toBe(true)
+    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY_THREE')).toBe(true)
+    expect(guaranteedFormationKeys.has('ARTEFACT_TWENTY')).toBe(true)
+
     // ── Artefact cascade ─────────────────────────────────────────────────────
     // Phase A of Pass 1 promotes single-candidate anchors immediately:
     //   C3=SDE → 1 candidate Arte20@(2,1) → D2='camel_bone' promoted


### PR DESCRIPTION
…hor reasoning

ARTEFACT_TWENTY_TWO/_THREE/_TWENTY share the same plot names across all present artefact shapes, so no name is confined to any one of them and enumerateSingleInstanceSurvivors falls back to a full-board scan that never narrows to one candidate — even though Pass 1's anchor reasoning already uniquely pinned the shape via a sharper, sound proof.

Thread the originating formation key through Pass 1's candidate computation and record a key as instance-confirmed the moment a single anchor reduces to exactly one surviving candidate for a shapeCount(key) === 1 formation, then union that into guaranteedFormationKeys at finalization. Purely reuses an existing soundness proof; duplicate-shaped keys are still excluded via the shapeCount gate.

Also make the guaranteed-pattern badge circular to match the grid's existing predicted-guaranteed badge, instead of inheriting the square shape from the server-completed badge.