### PR TITLE
Fix solver: stale confined-reveal anchors block remaining formation i…

### DIFF
--- a/src/dev/solverScenarios.js
+++ b/src/dev/solverScenarios.js
@@ -365,4 +365,30 @@ export const SOLVER_SCENARIOS = [
       { idx: 56, property: 'guaranteed', expected: false, label: '(6,5) idx 56 NOT guaranteed (Pipi only in one candidate)' },
     ],
   },
+
+  {
+    id: 'stale-confined-anchor-two-seaweed',
+    name: 'Stale confined-reveal anchor — two SEAWEED instances (grid ref F6, land 7242422682754425)',
+    // Instance A is fully confirmed via Starfish@(7,6) → pins Seaweed at
+    // (5,5),(6,5),(7,5). Instance B's own Seaweed reveal at (9,0) is far
+    // enough away that only a corner placement anchored there is legal.
+    // Without excluding instance A's already-committed cells from the
+    // confined-reveal anchor search, no single SEAWEED placement can cover
+    // both instances' reveals at once → zero survivors, instance B silently
+    // unforced. See tests/solver.scenarios.test.js for the full regression
+    // (asserts guaranteedFormationCounts too, not just per-cell `guaranteed`).
+    grid: [
+      { x: 7, y: 6, items: { Starfish: 1 } },
+      { x: 9, y: 0, items: { Seaweed: 1 } },
+    ],
+    patterns: ['SEAWEED', 'SEAWEED'],
+    assertions: [
+      { idx: 55, property: 'guaranteed', expected: true, label: 'instance A Seaweed (idx 55)' },
+      { idx: 56, property: 'guaranteed', expected: true, label: 'instance A Seaweed (idx 56)' },
+      { idx: 57, property: 'guaranteed', expected: true, label: 'instance A Seaweed (idx 57)' },
+      { idx: 7, property: 'guaranteed', expected: true, label: 'instance B Seaweed (idx 7) forced post-fix' },
+      { idx: 8, property: 'guaranteed', expected: true, label: 'instance B Seaweed (idx 8) forced post-fix' },
+      { idx: 19, property: 'guaranteed', expected: true, label: 'instance B Starfish (idx 19) forced post-fix' },
+    ],
+  },
 ]

--- a/src/utils/treasureSolver.js
+++ b/src/utils/treasureSolver.js
@@ -231,7 +231,9 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // and the whole-pattern-guarantee finalization below.
   const enumerateSingleInstanceSurvivors = (key) => {
     const formation = DIGGING_FORMATIONS[key]
-    const confined = [...revealedTreasureName].filter(([, name]) => confinedTo(name, key))
+    const confined = [...revealedTreasureName].filter(
+      ([idx, name]) => confinedTo(name, key) && !committedCellOrigin.has(idx),
+    )
 
     if (confined.length) {
       const [aIdx, aName] = confined[0]

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -487,6 +487,50 @@ describe('Edge cases', () => {
     // Both instances individually confirmed → count is 2, not 1.
     expect(guaranteedFormationCounts.get('HIEROGLYPH')).toBe(2)
   })
+
+  it('regression — stale confined-reveal anchors must not block the remaining SEAWEED instance (grid ref F6, land 7242422682754425)', () => {
+    // Root-caused against real land 7242422682754425: two SEAWEED instances on
+    // the board. Instance A is fully confirmed via its Starfish reveal at
+    // (7,6) — anchoring pins Seaweed at (5,5),(6,5),(7,5) [idx 55,56,57] and
+    // the Starfish itself [idx 76], all recorded in committedCellOrigin.
+    // Instance B has its own, separate Seaweed reveal at (9,0) [idx 9] — far
+    // enough from instance A that only a corner placement anchored there is
+    // geometrically legal.
+    //
+    // Bug (pre-fix): enumerateSingleInstanceSurvivors('SEAWEED') filtered
+    // confined reveals by name-confinement only, so it still included
+    // instance A's already-committed cells (55,56,57,76) alongside instance
+    // B's reveal (9). No single SEAWEED placement can cover both instances'
+    // cells at once, so the anchor search returned ZERO survivors —
+    // silently failing to confirm instance B or force its remaining tiles,
+    // even though a legal placement for it obviously exists.
+    //
+    // Fix: exclude any confined reveal already claimed via committedCellOrigin
+    // before anchoring, so the search for instance B's placement is anchored
+    // on idx 9 alone.
+    const grid = [
+      { x: 7, y: 6, items: { Starfish: 1 } }, // idx 76 — instance A anchor (fully confirms A)
+      { x: 9, y: 0, items: { Seaweed: 1 } },  // idx 9 — instance B's only reveal
+    ]
+    const patterns = ['SEAWEED', 'SEAWEED']
+    const tiles = gridArrayToTiles(grid, G)
+    const { guaranteed, guaranteedFormationCounts } = solveTreasures(tiles, patterns, G)
+
+    // Instance A: pinned regardless of the bug (single Starfish anchor).
+    expect(guaranteed.has(55), 'instance A Seaweed (idx 55)').toBe(true)
+    expect(guaranteed.has(56), 'instance A Seaweed (idx 56)').toBe(true)
+    expect(guaranteed.has(57), 'instance A Seaweed (idx 57)').toBe(true)
+
+    // Instance B: only discoverable once the stale-anchor bug is fixed —
+    // the sole legal placement covering idx 9 also forces idx 7 and idx 8
+    // (Seaweed) and idx 19 (Starfish).
+    expect(guaranteed.has(7), 'instance B Seaweed (idx 7) — blocked by the bug pre-fix').toBe(true)
+    expect(guaranteed.has(8), 'instance B Seaweed (idx 8) — blocked by the bug pre-fix').toBe(true)
+    expect(guaranteed.has(19), 'instance B Starfish (idx 19) — blocked by the bug pre-fix').toBe(true)
+
+    // Both instances individually confirmed → count is 2, not 1.
+    expect(guaranteedFormationCounts.get('SEAWEED')).toBe(2)
+  })
 })
 
 // ── Instance-consumption cascade — land 1405000790165644 ─────────────────────


### PR DESCRIPTION
…nstances

enumerateSingleInstanceSurvivors filtered confined reveals by name-confinement only, so once one instance of a shape was already committed (via committedCellOrigin), searching for a still-unfound instance of the same shape got fed a mix of already-explained and still-open reveals that no single placement can jointly satisfy — returning zero survivors and silently failing to confirm/force the remaining instance.

Exclude already-committed cells from the anchor search. Adds a SEAWEED regression scenario reproducing the case found on land 7242422682754425.