### PR TITLE
fix: mirror sync data to development + season-agnostic tests

### DIFF
--- a/.github/workflows/sync-artefact.yml
+++ b/.github/workflows/sync-artefact.yml
@@ -56,6 +56,9 @@ jobs:
           git add -A
           git commit -m "chore: Sync artefact data from SFL repo [$(date +'%Y-%m-%d')]"
           git push
+          # Also fast-forward the development branch so beta never lags a season.
+          # Rejected (non-fast-forward) if dev has unmerged work -> run fails loudly.
+          git push origin HEAD:development
       
       - name: No changes detected
         if: steps.git-check.outputs.changed != 'true'

--- a/.github/workflows/sync-artefact.yml
+++ b/.github/workflows/sync-artefact.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,13 +57,31 @@ jobs:
           git add -A
           git commit -m "chore: Sync artefact data from SFL repo [$(date +'%Y-%m-%d')]"
           git push
-          # Also fast-forward the development branch so beta never lags a season.
-          # Rejected (non-fast-forward) if dev has unmerged work -> run fails loudly.
-          git push origin HEAD:development
       
       - name: No changes detected
         if: steps.git-check.outputs.changed != 'true'
         run: echo "No season updates detected. Everything is up to date!"
+
+      - name: Mirror data files to development branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin development
+          # Guard: never overwrite local dev edits to data files. If development
+          # has commits touching these paths that master doesn't, skip + warn.
+          if [ -n "$(git log HEAD..origin/development --oneline -- src/data/game/ public/world/)" ]; then
+            echo "::warning::development has local changes under src/data/game/ or public/world/ not on master - skipping mirror"
+            exit 0
+          fi
+          SYNC_SHA=$(git rev-parse HEAD)
+          git checkout -B sync-dev origin/development
+          git checkout "$SYNC_SHA" -- src/data/game/ public/world/
+          if ! git diff --cached --quiet; then
+            git commit -m "🤖 Mirror artefact data from master ($(git rev-parse --short "$SYNC_SHA"))"
+            git push origin sync-dev:development
+          else
+            echo "development data already up to date"
+          fi
 
 
 

--- a/.github/workflows/sync-game-data.yml
+++ b/.github/workflows/sync-game-data.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
       
       - uses: actions/setup-node@v4
         with:
@@ -40,9 +41,27 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "🤖 Auto-sync: Update game data [$(date -u '+%Y-%m-%d %H:%M UTC')]"
             git push
-            # Also fast-forward the development branch so beta never lags a season.
-            # Rejected (non-fast-forward) if dev has unmerged work -> run fails loudly.
-            git push origin HEAD:development
           fi
       
+      - name: Mirror data files to development branch
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git fetch origin development
+          # Guard: never overwrite local dev edits to data files. If development
+          # has commits touching these paths that master doesn't, skip + warn.
+          if [ -n "$(git log HEAD..origin/development --oneline -- src/data/game/)" ]; then
+            echo "::warning::development has local changes under src/data/game/ not on master - skipping mirror"
+            exit 0
+          fi
+          SYNC_SHA=$(git rev-parse HEAD)
+          git checkout -B sync-dev origin/development
+          git checkout "$SYNC_SHA" -- src/data/game/
+          if ! git diff --cached --quiet; then
+            git commit -m "🤖 Mirror game data from master ($(git rev-parse --short "$SYNC_SHA"))"
+            git push origin sync-dev:development
+          else
+            echo "development data already up to date"
+          fi
+
       - run: rm -rf temp/

--- a/.github/workflows/sync-game-data.yml
+++ b/.github/workflows/sync-game-data.yml
@@ -40,6 +40,9 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "🤖 Auto-sync: Update game data [$(date -u '+%Y-%m-%d %H:%M UTC')]"
             git push
+            # Also fast-forward the development branch so beta never lags a season.
+            # Rejected (non-fast-forward) if dev has unmerged work -> run fails loudly.
+            git push origin HEAD:development
           fi
       
       - run: rm -rf temp/

--- a/src/dev/solverScenarios.js
+++ b/src/dev/solverScenarios.js
@@ -1,4 +1,10 @@
 // src/dev/solverScenarios.js
+import { getCurrentSeasonalArtefact } from '@/data/game/seasonalArtefacts.js'
+
+// The seasonal artefact's name rotates every season; boards below reference
+// it by name so this regression suite stays valid across season changes.
+const SEASONAL = getCurrentSeasonalArtefact()
+
 export const SOLVER_SCENARIOS = [
   {
     id: 'pass1-vase',
@@ -405,20 +411,20 @@ export const SOLVER_SCENARIOS = [
     // regression (also asserts guaranteedFormationCounts).
     grid: [
       { x: 8, y: 8, items: { 'Camel Bone': 1 } },
-      { x: 7, y: 8, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 8, items: { [SEASONAL]: 1 } },
       { x: 1, y: 8, items: { Crab: 1 } },
       { x: 2, y: 8, items: { 'Cockle Shell': 1 } },
       { x: 3, y: 9, items: { 'Cockle Shell': 1 } },
       { x: 1, y: 1, items: { 'Camel Bone': 1 } },
       { x: 2, y: 1, items: { 'Camel Bone': 1 } },
-      { x: 1, y: 0, items: { 'Salt Dino Egg': 1 } },
+      { x: 1, y: 0, items: { [SEASONAL]: 1 } },
       { x: 8, y: 1, items: { Sand: 2 } },
       { x: 5, y: 1, items: { Sand: 2 } },
       { x: 8, y: 4, items: { Crab: 1 } },
       { x: 7, y: 4, items: { Crab: 1 } },
       { x: 8, y: 5, items: { 'Camel Bone': 1 } },
       { x: 7, y: 5, items: { 'Cockle Shell': 1 } },
-      { x: 9, y: 6, items: { 'Salt Dino Egg': 1 } },
+      { x: 9, y: 6, items: { [SEASONAL]: 1 } },
       { x: 1, y: 3, items: { Crab: 1 } },
       { x: 1, y: 4, items: { Sand: 2 } },
       { x: 2, y: 3, items: { Wood: 1 } },

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -9,6 +9,7 @@ import { solveTreasures } from '@/utils/treasureSolver.js'
 import { gridArrayToTiles } from '@/utils/gridTileTransform.js'
 import { buildGuaranteedIndexes } from '@/utils/patternPreview.js'
 import { DIGGING_FORMATIONS } from '@/data/game/diggingFormations.js'
+import { getCurrentSeasonalArtefact } from '@/data/game/seasonalArtefacts.js'
 
 const G = 10
 
@@ -21,10 +22,18 @@ function label(idx) {
 }
 
 const SLUG_ABBR = {
-  camel_bone: 'CB', salt_dino_egg: 'SDE', cockle_shell: 'CK',
+  camel_bone: 'CB', cockle_shell: 'CK',
   clam_shell: 'CS', vase: 'V', hieroglyph: 'H', seaweed: 'SW',
   wooden_compass: 'WC', wood: 'WD', old_bottle: 'OB',
 }
+
+// The seasonal artefact's name/slug rotate every season (see
+// seasonalArtefacts.js). The artefact boards below reference it by name so
+// this suite stays green across season changes instead of hardcoding one
+// season's artefact (which breaks the moment CURRENT_SEASONAL_ARTEFACT moves).
+const SEASONAL = getCurrentSeasonalArtefact()
+const SEASONAL_SLUG = SEASONAL.toLowerCase().replace(/\s+/g, '_')
+SLUG_ABBR[SEASONAL_SLUG] = 'ART'
 
 function renderFormation(key) {
   const plots = DIGGING_FORMATIONS[key]
@@ -218,11 +227,11 @@ describe('Edge cases', () => {
       { x: 2, y: 1, items: { 'Camel Bone': 1 } },
       { x: 3, y: 2, items: { 'Camel Bone': 1 } },
       { x: 4, y: 2, items: { Crab: 1 } },
-      { x: 2, y: 2, items: { 'Salt Dino Egg': 1 } },
-      { x: 8, y: 1, items: { 'Salt Dino Egg': 1 } },
+      { x: 2, y: 2, items: { [SEASONAL]: 1 } },
+      { x: 8, y: 1, items: { [SEASONAL]: 1 } },
       { x: 8, y: 3, items: { Sand: 2 } },
       { x: 8, y: 6, items: { Crab: 1 } },
-      { x: 7, y: 6, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 6, items: { [SEASONAL]: 1 } },
       { x: 4, y: 8, items: { 'Clam Shell': 1 } },
       { x: 3, y: 7, items: { Crab: 1 } },
       { x: 4, y: 7, items: { Crab: 1 } },
@@ -340,7 +349,7 @@ describe('Edge cases', () => {
       { x: 0, y: 8, items: { Crab: 1 } },
       { x: 8, y: 2, items: { Vase: 1 } },
       { x: 7, y: 3, items: { Hieroglyph: 1 } },
-      { x: 7, y: 8, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 8, items: { [SEASONAL]: 1 } },
       { x: 3, y: 1, items: { Sand: 1 } },
       { x: 4, y: 3, items: { Sand: 1 } },
       { x: 2, y: 5, items: { 'Clam Shell': 1 } },
@@ -398,11 +407,11 @@ describe('Edge cases', () => {
       { x: 2, y: 1, items: { 'Camel Bone': 1 } },
       { x: 3, y: 2, items: { 'Camel Bone': 1 } },
       { x: 4, y: 2, items: { Crab: 1 } },
-      { x: 2, y: 2, items: { 'Salt Dino Egg': 1 } },
-      { x: 8, y: 1, items: { 'Salt Dino Egg': 1 } },
+      { x: 2, y: 2, items: { [SEASONAL]: 1 } },
+      { x: 8, y: 1, items: { [SEASONAL]: 1 } },
       { x: 8, y: 3, items: { Sand: 2 } },
       { x: 8, y: 6, items: { Crab: 1 } },
-      { x: 7, y: 6, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 6, items: { [SEASONAL]: 1 } },
       { x: 4, y: 8, items: { 'Clam Shell': 1 } },
       { x: 3, y: 7, items: { Crab: 1 } },
       { x: 4, y: 7, items: { Crab: 1 } },
@@ -549,13 +558,13 @@ describe('Edge cases', () => {
     const grid = [
       { x: 8, y: 8, items: { Sand: 2 } },
       { x: 1, y: 8, items: { 'Camel Bone': 1 } },
-      { x: 0, y: 8, items: { 'Salt Dino Egg': 1 } },
+      { x: 0, y: 8, items: { [SEASONAL]: 1 } },
       { x: 1, y: 1, items: { Crab: 1 } },
       { x: 1, y: 2, items: { 'Cockle Shell': 1 } },
       { x: 0, y: 1, items: { 'Cockle Shell': 1 } },
       { x: 8, y: 1, items: { Crab: 1 } },
       { x: 8, y: 2, items: { 'Camel Bone': 1 } },
-      { x: 7, y: 2, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 2, items: { [SEASONAL]: 1 } },
       { x: 5, y: 8, items: { Crab: 1 } },
       { x: 5, y: 7, items: { Vase: 1 } },
       { x: 3, y: 1, items: { Sand: 2 } },
@@ -565,7 +574,7 @@ describe('Edge cases', () => {
       { x: 4, y: 4, items: { 'Camel Bone': 1 } },
       { x: 3, y: 4, items: { Crab: 1 } },
       { x: 3, y: 3, items: { Crab: 1 } },
-      { x: 4, y: 3, items: { 'Salt Dino Egg': 1 } },
+      { x: 4, y: 3, items: { [SEASONAL]: 1 } },
       { x: 6, y: 6, items: { Crab: 1 } },
       { x: 5, y: 6, items: { 'Clam Shell': 1 } },
       { x: 4, y: 6, items: { 'Clam Shell': 1 } },
@@ -626,20 +635,20 @@ describe('Edge cases', () => {
     //     confirmation of idx 2 = Camel Bone was silently dropped.
     const grid = [
       { x: 8, y: 8, items: { 'Camel Bone': 1 } },
-      { x: 7, y: 8, items: { 'Salt Dino Egg': 1 } },
+      { x: 7, y: 8, items: { [SEASONAL]: 1 } },
       { x: 1, y: 8, items: { Crab: 1 } },
       { x: 2, y: 8, items: { 'Cockle Shell': 1 } },
       { x: 3, y: 9, items: { 'Cockle Shell': 1 } },
       { x: 1, y: 1, items: { 'Camel Bone': 1 } },
       { x: 2, y: 1, items: { 'Camel Bone': 1 } },
-      { x: 1, y: 0, items: { 'Salt Dino Egg': 1 } },
+      { x: 1, y: 0, items: { [SEASONAL]: 1 } },
       { x: 8, y: 1, items: { Sand: 2 } },
       { x: 5, y: 1, items: { Sand: 2 } },
       { x: 8, y: 4, items: { Crab: 1 } },
       { x: 7, y: 4, items: { Crab: 1 } },
       { x: 8, y: 5, items: { 'Camel Bone': 1 } },
       { x: 7, y: 5, items: { 'Cockle Shell': 1 } },
-      { x: 9, y: 6, items: { 'Salt Dino Egg': 1 } },
+      { x: 9, y: 6, items: { [SEASONAL]: 1 } },
       { x: 1, y: 3, items: { Crab: 1 } },
       { x: 1, y: 4, items: { Sand: 2 } },
       { x: 2, y: 3, items: { Wood: 1 } },
@@ -700,7 +709,7 @@ describe('Instance-consumption cascade — land 1405000790165644', () => {
     { x: 0, y: 8, items: { Crab: 1 } },
     { x: 8, y: 2, items: { Vase: 1 } },
     { x: 7, y: 3, items: { Hieroglyph: 1 } },
-    { x: 7, y: 8, items: { 'Salt Dino Egg': 1 } },
+    { x: 7, y: 8, items: { [SEASONAL]: 1 } },
     { x: 3, y: 1, items: { Sand: 1 } },
     { x: 4, y: 3, items: { Sand: 1 } },
     { x: 2, y: 5, items: { 'Clam Shell': 1 } },
@@ -729,7 +738,7 @@ describe('Instance-consumption cascade — land 1405000790165644', () => {
     expect(guaranteed.has(83), 'D9 camel_bone').toBe(true)
     expect(guaranteedSlugs.get(83)).toBe('camel_bone')
     expect(guaranteed.has(92), 'C10 salt_dino_egg').toBe(true)
-    expect(guaranteedSlugs.get(92)).toBe('salt_dino_egg')
+    expect(guaranteedSlugs.get(92)).toBe(SEASONAL_SLUG)
   })
 
   it('ARTE_23 locked to (5,7) by H9: guarantees F8/G8/H8/G9', () => {
@@ -747,7 +756,7 @@ describe('Instance-consumption cascade — land 1405000790165644', () => {
     const { guaranteed, guaranteedSlugs } = solveTreasures(tiles, patterns, G)
     // F3=(5,2) idx 25 = SDE, G2=(6,1) idx 16 = CB, G3=(6,2) idx 26 = CB
     expect(guaranteed.has(25), 'F3 salt_dino_egg').toBe(true)
-    expect(guaranteedSlugs.get(25)).toBe('salt_dino_egg')
+    expect(guaranteedSlugs.get(25)).toBe(SEASONAL_SLUG)
     expect(guaranteed.has(16), 'G2 camel_bone').toBe(true)
     expect(guaranteedSlugs.get(16)).toBe('camel_bone')
     expect(guaranteed.has(26), 'G3 camel_bone').toBe(true)


### PR DESCRIPTION
## Summary
Three commits from development:

1. **3d8b32b** - fix: make solver scenario tests season-agnostic
   - Scenario boards no longer hardcode the seasonal artefact (Salt Dino Egg); they resolve the current season dynamically, so the test suite stops breaking every monthly artefact rotation.

2. **8ea2034** - fix: sync GHA game-data/artefact pushes to development branch too
   - Data sync commits were landing on master only, so development (beta) drifted a season behind every artefact rotation (e.g. missing `otter_pebble.webp` on beta).

3. **2e4edcd** - fix: mirror sync data onto development via file-level apply
   - Replaces the plain `push HEAD:development` with a file-level mirror step in both sync workflows: after the master commit, the data paths (`src/data/game/`, `public/world/` for artefact) are checked out from the sync commit onto development and committed. Works even when development is ahead with app work, and can never create merge conflicts (files are copied, not merged). A guard skips with a warning if development has local edits to the data paths.

## Verification
- `npm test`: 56/56 passed
- `npm run build`: clean
- Mirror step tested end-to-end in a disposable clone (dev-ahead case + guard case)
- Merge is a clean fast-forward: master is a pure ancestor of development