### PR TITLE
docs: document sync data mirror to development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Read in this order; each doc is kept accurate. If anything here conflicts with o
 | **AGENTS.md** (this file) | Dev commands, conventions, env, API-proxy quirks, dead-code register |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Full architecture: directories, routes, startup, data flow, composables/services, grid-builders, entrypoints, `src_other` |
 | [docs/GRID_MECHANICS.md](docs/GRID_MECHANICS.md) | The 10×10 grid engine: tiles, hints, formations, practice mode |
+| [docs/API_LAYER.md](docs/API_LAYER.md) | **Request pipeline + caching policy for the SFL farm API** — read before touching anything that fetches land data |
 | [docs/DIG_DAY_SYNC.md](docs/DIG_DAY_SYNC.md) | Dig-day Hub sync: debounce, ETag, merge-by-seq, the layers |
 | [docs/HUB_CONSUMPTION_SPEC.md](docs/HUB_CONSUMPTION_SPEC.md) | Hub-side ETag/idempotency contract |
 | [netlify/functions/README.md](netlify/functions/README.md) | Per-function reference for the `.cjs` proxies |
@@ -133,7 +134,8 @@ Both sync workflows commit + push to `master`, then **mirror the data files to `
 
 ## API proxy details
 
-- `sfl-api.cjs` has a 60s in-memory cache for 200 responses. Bypass with `x-sfl-bypass-cache: 1` header or `?bypassCache=1` — the app sends this on every land sync.
+- `sfl-api.cjs` has a 60s in-memory cache for 200 responses. Bypass with `x-sfl-bypass-cache: 1` header or `?bypassCache=1` — the app sends this **only** on explicit user refreshes and env switches (see [docs/API_LAYER.md](docs/API_LAYER.md)); auto loads go through the proxy cache.
+- **All land-data requests go through `src/services/landFetchCoordinator.js`** (single-flight, 5-min localStorage freshness, cooldown). Never call `fetchLandDataFromServer()` from a component.
 - `/visit/*` often returns 401 for third-party tools. The app uses `/community/farms/*` as primary and `/visit/*` as fallback only.
 - Prod/test API switching is communicated via `x-sfl-api-env` header. Land data cache keys are prefixed per-environment (`landData_` vs `landData_test_`).
 - Practice patterns are CDN-cached until UTC midnight (`CDN-Cache-Control` headers).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,11 +123,13 @@ Routes: `/`, `/digging`, `/practice`, `/:landId/digging`, `/:landId/digging/hist
 ## Auto-generated data (do not edit)
 
 `src/data/game/` files are synced from the Sunflower Land repo by CI:
-- `treasurePrices.json` / `gameConstants.json` — `npm run sync-game-data` (daily CI)
+- `treasurePrices.json` / `gameConstants.json` — `npm run sync-game-data` (weekly CI, Sundays 00:00 UTC)
 - `seasonalArtefacts.js` — `npm run sync-artefact` (monthly CI)
 - `diggingFormations.js` — imported from game data
 
 Three GitHub Actions auto-commit to the repo: `sync-game-data.yml`, `sync-artefact.yml`, `warm-daily-cache.yml`.
+
+Both sync workflows commit + push to `master`, then **mirror the data files to `development`** via a file-level checkout (`src/data/game/`, plus `public/world/` for artefact) — no fast-forward requirement, no merge conflicts, so beta never drifts a season behind. The mirror is skipped with a warning if `development` has local edits to those paths that `master` doesn't have. Result: prod (`master`) and beta (`development`) stay on identical game data.
 
 ## API proxy details
 

--- a/SEASON_UPDATE_GUIDE.md
+++ b/SEASON_UPDATE_GUIDE.md
@@ -8,20 +8,21 @@ Every few months, Sunflower Land releases a new chapter/season. This guide helps
 
 ### How It Works
 
-- **Automatic:** Runs on the 1st of every month at 00:00 UTC
+- **Automatic:** Runs on the 1st–3rd of every month at 00:00 UTC
 - **Manual Trigger:** You can also trigger it manually from GitHub Actions tab
 - **What It Does:**
   1. Fetches latest season data from SFL repository
   2. Updates `src/data/game/seasonalArtefacts.js` if changes detected
   3. Downloads new artifact `.webp` images to `public/world/`
-  4. Commits and pushes changes automatically to `development` branch
+  4. Commits and pushes the changes to `master`
+  5. **Mirrors the data files to `development`** via a file-level copy (no merge, no conflicts) so beta stays in sync
 
 ### Manual Trigger
 
 1. Go to: https://github.com/jovylle/sfl-crab/actions
-2. Select "Update Seasons Data" workflow
+2. Select the "Sync Artefact Data - v1.3" workflow
 3. Click "Run workflow" button
-4. Select branch (usually `development`)
+4. Select branch — leave it on the default (`master`). Do **not** pick `development`: the workflow commits to the branch it runs on, and running from `development` would skip `master` entirely.
 5. Click "Run workflow" green button
 
 ### Test Locally Before Deployment
@@ -184,9 +185,10 @@ git push
 ### GitHub Actions Workflow
 
 The automation is defined in `.github/workflows/sync-artefact.yml`:
-- Scheduled to run monthly
-- Can be triggered manually
-- Automatically commits changes if updates are found
+- Scheduled to run monthly (1st–3rd at 00:00 UTC)
+- Can be triggered manually (from `master` — see above)
+- Commits changes to `master`, then mirrors `src/data/game/` + `public/world/` to `development`
+- The mirror is a file-level copy (`git checkout <sync-sha> -- <paths>`), so it never creates merge conflicts; if `development` has local edits to the data paths that `master` doesn't have, the mirror is skipped with a warning instead of overwriting them
 
 ### Update Script
 
@@ -206,5 +208,5 @@ The script `scripts/sync-artefact.js`:
 
 ---
 
-**Last Updated:** November 2025
+**Last Updated:** August 2026
 

--- a/docs/API_LAYER.md
+++ b/docs/API_LAYER.md
@@ -28,7 +28,8 @@ landSyncService / landApiService (src/services/*.js)   ← pure fetch, error map
    │  prod → test env fallback, 429 message mapping
    ▼
 Netlify proxy  sfl-api.cjs (netlify/functions/sfl-api.cjs)   ← server-side key,
-   │  60s in-memory cache, bypassable via x-sfl-bypass-cache
+   │  60s in-memory cache, bypassable via x-sfl-bypass-cache;
+   │  responds Cache-Control: no-store → no browser/CDN HTTP caching
    ▼
 Sunflower Land public API (api.sunflower-land.com | api-dev.sunflower-land.com)
 ```
@@ -59,10 +60,20 @@ ETag + freshness cache + force flag. See [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md).
 | Coordinator single-flight | in-flight Promise per `env:landId` | duration of request | — (shared by design) |
 | localStorage cache (`landData_<env>_<id>`) | `{ date, fetchedAt, visitedFarmState }` | until UTC date changes; "fresh" while < `LAND_CACHE_FRESH_MS` (5 min) | `force: true` or `bypassCache: true` |
 | Cooldown (`landCooldownEnd_<env>_<id>`) | timestamp | 15s after success, 30s after failure | `force: true` only |
+| Browser HTTP cache | **disabled** — `sfl-api.cjs` sends `Cache-Control: no-store` on every response | never | — (by design; see golden rule 5) |
 
 Cache keys are env-prefixed (`landData_` vs `landData_test_`) so prod and test
 snapshots never mix — see `getLandDataStorageKey()` / `getLandCooldownStorageKey()`
 in `src/config/api.js`.
+
+**Netlify CDN / edge caching is deliberately NOT used for land data.** The only
+place edge caching exists is `practice-patterns.cjs` (`CDN-Cache-Control` until
+UTC midnight) — appropriate because daily patterns are immutable within a day.
+Land data is per-farm and changes as the player digs, so the 60s in-memory
+proxy cache is the outermost cache it gets. (History: the in-memory cache came
+first — `8254d9c` — and the bypass header `61272c1` exists because refreshes
+must stay fresh; the coordinator is what finally routes auto loads *through*
+the cache.)
 
 ## Policy table (`requestLandData(landId, { force, bypassCache })`)
 
@@ -103,3 +114,9 @@ only for explicit refreshes.
    neither checked nor set it, so repeated navigation fired unthrottled API calls.
 4. **Freshness is advisory unless enforced.** `landCache.js` computed
    `shouldAutoFetch` for years, but callers fired anyway. The coordinator enforces it.
+5. **"Refresh Data" never touches a cache.** The whole chain is cache-proof:
+   `bypassCache: true` skips the localStorage freshness check AND the proxy's
+   in-memory cache; `sfl-api.cjs` responds `Cache-Control: no-store` so the
+   browser HTTP cache can never serve land data; the button is disabled during
+   the 15s cooldown (no silent no-op). If a refresh ever shows data you've seen
+   before, that's a bug — every cache layer must be bypassable.

--- a/docs/API_LAYER.md
+++ b/docs/API_LAYER.md
@@ -1,0 +1,105 @@
+# API Layer
+
+> Canonical reference for how **sfl-crab / d1g.uk** talks to the Sunflower Land farm API and the Digging Hub. Read this before touching anything that fetches land data. It documents the **request pipeline, every trigger point, every caching layer, and the bypass/cooldown policy** — the stuff that used to be scattered across six files.
+
+## The one rule
+
+> **Never call `fetchLandDataFromServer()` from a component or composable.**
+> All land-data requests go through `requestLandData()` in
+> `src/services/landFetchCoordinator.js`. If you find a direct call, it's a bug.
+
+## Request pipeline (land data)
+
+```
+Component / view
+   │  e.g. Digging.vue onMounted, LandLoader, RefreshLandData,
+   │       PracticeDigging "start round", useApiEnvironmentSwitch
+   ▼
+useLandSync (src/composables/useLandSync.js)     ← UI state only
+   │  isLoading / isCooldown / remaining countdown, dispatch landDataReady
+   ▼
+landFetchCoordinator (src/services/landFetchCoordinator.js)   ← ALL decisions
+   │  1. fresh localStorage cache?   → return, zero network
+   │  2. cooldown active?            → serve stale cache, zero network
+   │  3. in-flight same (env,land)?  → join it (single-flight)
+   │  4. else fetch + write cache + arm cooldown
+   ▼
+landSyncService / landApiService (src/services/*.js)   ← pure fetch, error mapping
+   │  prod → test env fallback, 429 message mapping
+   ▼
+Netlify proxy  sfl-api.cjs (netlify/functions/sfl-api.cjs)   ← server-side key,
+   │  60s in-memory cache, bypassable via x-sfl-bypass-cache
+   ▼
+Sunflower Land public API (api.sunflower-land.com | api-dev.sunflower-land.com)
+```
+
+## Every trigger point (what fires a request)
+
+| Trigger | Caller | Mode | Result |
+|---|---|---|---|
+| Land page mounts, cache stale (>5 min) | `Digging.vue` onMounted | auto | 1 network call (single-flight with LandLoader) |
+| Land selected via LandLoader | `LandLoader.vue` goToLand | auto | joins the mount's request — never a second call |
+| User clicks "Refresh Data" | `RefreshLandData.vue` | `bypassCache: true` | fresh from SFL API, respects 15s cooldown (button disabled during it) |
+| Prod ↔ testnet switch | `useApiEnvironmentSwitch` | `force: true, bypassCache: true` | fresh from the other server, skips cooldown |
+| Practice "today's round" on a land | `PracticeDigging.vue` startLandRound | auto | reuses the digging page's cache if fresh |
+| Practice patterns (hub) | `usePracticePatterns` | auto | separate path — own single-flight + daily cache, see below |
+
+The **practice patterns** path (`/api/practice-patterns` via `practicePatternService.js`)
+is separate: it has its own single-flight (`ongoingFetch` + `window[...]` key in
+`usePracticePatterns.js`) and a per-day localStorage cache. Leave it alone.
+
+The **dig-day hub** path (`digDayApiService.js`) is also separate and already good:
+ETag + freshness cache + force flag. See [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md).
+
+## Caching layers (land data)
+
+| Layer | What it holds | Lifetime | Bypassed by |
+|---|---|---|---|
+| Proxy in-memory cache (`sfl-api.cjs`) | last 200 response per `env:path` | 60s | `bypassCache: true` (user refresh, env switch) |
+| Coordinator single-flight | in-flight Promise per `env:landId` | duration of request | — (shared by design) |
+| localStorage cache (`landData_<env>_<id>`) | `{ date, fetchedAt, visitedFarmState }` | until UTC date changes; "fresh" while < `LAND_CACHE_FRESH_MS` (5 min) | `force: true` or `bypassCache: true` |
+| Cooldown (`landCooldownEnd_<env>_<id>`) | timestamp | 15s after success, 30s after failure | `force: true` only |
+
+Cache keys are env-prefixed (`landData_` vs `landData_test_`) so prod and test
+snapshots never mix — see `getLandDataStorageKey()` / `getLandCooldownStorageKey()`
+in `src/config/api.js`.
+
+## Policy table (`requestLandData(landId, { force, bypassCache })`)
+
+| Caller intent | force | bypassCache | Fresh cache? | Cooldown? | Network? |
+|---|---|---|---|---|---|
+| Auto load (mount, navigation, practice round) | false | false | served | suppresses call | only if cache stale AND no cooldown |
+| User "Refresh Data" | false | true | skipped | respected | yes (through proxy cache bypass) |
+| Env switch | true | true | skipped | skipped | yes |
+
+Notes:
+- **Auto ≠ bypass.** Auto loads intentionally pass through the proxy cache — a
+  repeat visit inside 60s is served by the proxy, not the SFL API.
+- **Every network hit arms the cooldown**, including auto fetches. This is what
+  stops navigation spam: mount → fetch → 15s window where remounts serve cache.
+- `force` is reserved for the env switch. If you're tempted to use it elsewhere,
+  you're probably trying to work around a policy bug — fix the policy instead.
+
+## localStorage keys
+
+All land-data keys live in `src/config/api.js` (builders) and
+`src/constants/storageKeys.js` (fixed keys). Same for every other app key.
+
+## Observability
+
+The proxy logs one line per request: `sfl-api { env, path, landId, status, cache }`
+where cache ∈ `hit | miss | bypass`. In the Netlify function logs you can verify
+the policy is working: auto reloads inside 60s should show `hit` or `bypass`
+only for explicit refreshes.
+
+## Golden rules (why they exist)
+
+1. **Single door to the SFL API** — dedup and cooldown only work if every caller
+   goes through the coordinator. A direct call (the old `PracticeDigging.vue:595`)
+   silently bypasses everything.
+2. **Auto loads serve cache, refreshes force.** The proxy cache exists to absorb
+   repeat traffic; `bypassCache` on every sync (the old behavior) made it dead.
+3. **Cooldown is armed on every network hit.** Old `skipCooldown: true` callers
+   neither checked nor set it, so repeated navigation fired unthrottled API calls.
+4. **Freshness is advisory unless enforced.** `landCache.js` computed
+   `shouldAutoFetch` for years, but callers fired anyway. The coordinator enforces it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,11 +130,13 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 
 ## Data flow (live land)
 
-1. **Fetch** — `landApiService.js` → `/.netlify/functions/sfl-api/community/farms/:id` → SFL API. The app sends `bypassCache` to skip the proxy's own 60s cache on manual syncs.
+> Full request pipeline + caching policy: see [API_LAYER.md](./API_LAYER.md).
+
+1. **Fetch** — every caller goes through `landFetchCoordinator.js` (`requestLandData()`), which applies single-flight, a 5-min localStorage freshness check, and the cooldown policy. It calls `landSyncService` → `landApiService.js` → `/.netlify/functions/sfl-api/community/farms/:id` → SFL API.
 2. **Response shape** — `{ visitedFarmState: { desert: { digging: { grid, patterns, completedPatterns } } } }`. Grid tiles are `{ x, y, items: { Crab | Sand | <TreasureName> }, dugAt, tool }`.
 3. **Store** — `useLandData.js` holds reactive land data + localStorage cache, keyed per land + API env, UTC-date-stamped (stale after the UTC date changes).
 4. **Render** — `useGridEngine.js` converts API tiles → CSS class arrays and rebuilds neighbor hints (`near-*`). See [GRID_MECHANICS.md](./GRID_MECHANICS.md).
-5. **Cooldowns** — 15s between successful refreshes, 30s after failures (`useLandSync.js`).
+5. **Cooldowns** — 15s between successful refreshes, 30s after failures, armed by the coordinator on every network hit (`useLandSync.js` only renders the countdown UI).
 
 ## Key composables
 
@@ -143,7 +145,7 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 | `useGridEngine.js` ⭐ | Core 10×10 grid + auto neighbor-hint propagation |
 | `useGridManager.js` | User marks / manual hint cycling |
 | `useLandData.js` ⭐ | Central land-data store + localStorage cache; `solverPatternKeys` is the historical-aware solver-input source shared by Grid.vue/TodayPatterns.vue on both digging pages |
-| `useLandSync.js` | Refresh cooldowns, `bypassCache` |
+| `useLandSync.js` | Refresh UI state (isLoading/isCooldown/countdown) — network decisions delegated to `landFetchCoordinator` |
 | `useDigDayStore.js` | Hub dig-day sync (debounce/ETag/merge) — see [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md) |
 | `usePracticeEngine.js` / `usePracticePatterns.js` | Practice mode grid generation + daily patterns |
 | `useHintsStorage.js` | Per-land per-UTC-day hint persistence |
@@ -156,7 +158,7 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 
 ## Services (`src/services/`)
 
-All hit the `/api/*` Netlify proxies. `landApiService.js`, `landSyncService.js`, `digDayApiService.js`, `hubAuthService.js`, `hubProfileService.js`, `practiceHubService.js`, `practicePatternService.js`, `practiceRunApiService.js`, `adminBlobService.js`. Hub calls attach `Authorization: Bearer <token>` via `src/features/hub/hubClient.js` when a session exists.
+All hit the `/api/*` Netlify proxies — per-service reference in [../src/services/README.md](../src/services/README.md). `landFetchCoordinator.js` ⭐ is the single door to the SFL farm API (single-flight, freshness, cooldown — see [API_LAYER.md](./API_LAYER.md)); `landApiService.js`, `landSyncService.js`, `digDayApiService.js`, `hubAuthService.js`, `hubProfileService.js`, `practiceHubService.js`, `practicePatternService.js`, `practiceRunApiService.js`, `adminBlobService.js`. Hub calls attach `Authorization: Bearer <token>` via `src/features/hub/hubClient.js` when a session exists.
 
 ## Grid builder utils (the 4 overlapping files)
 
@@ -193,6 +195,7 @@ Known non-functional or trap-laden spots. Documented so an AI doesn't waste time
 ## Related docs
 
 - [AGENTS.md](../AGENTS.md) — dev commands, conventions, env, API proxy quirks
+- [API_LAYER.md](./API_LAYER.md) — SFL farm API request pipeline + caching/cooldown policy
 - [GRID_MECHANICS.md](./GRID_MECHANICS.md) — grid engine, hints, formations, practice mode
 - [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md) — dig-day hub sync (debounce/ETag/merge)
 - [HUB_CONSUMPTION_SPEC.md](./HUB_CONSUMPTION_SPEC.md) — hub ETag/idempotency spec

--- a/docs/GRID_MECHANICS.md
+++ b/docs/GRID_MECHANICS.md
@@ -8,11 +8,15 @@ See `src/composables/useGridEngine.js` for the grid engine, `src/composables/use
 
 | Class | Meaning |
 |---|---|
-| `sand` | Empty/undisturbed tile |
-| `crab` | Crab tile — **always orthogonally adjacent to a treasure** |
-| `treasure actual-treasure` | Treasure tile — always surrounded by crabs |
+| `sand` | Empty tile — provably not a treasure |
+| `crab` | Crab tile — **always orthogonally adjacent to at least one treasure** |
+| `treasure actual-treasure` | Treasure tile — its in-bounds orthogonal neighbours are **treasures or crabs, never sand** |
 
-**The fundamental game rule**: every treasure has crabs in its 4 orthogonal neighbors (if within bounds). The hint system exploits this — if you see a crab, a treasure is adjacent. If you see multiple known crabs, their intersection is a guaranteed treasure location.
+**The fundamental game rules** (these are the invariants the solver exploits):
+
+1. **Treasure-neighbour rule**: every in-bounds orthogonal neighbour of a treasure is either a treasure (an adjacent plot of the same formation — e.g. the two `Vase` tiles of `HIEROGLYPH` touch) or a crab — **never sand or empty**. The practice engine encodes this directly: it auto-places crabs on *all unoccupied* orthogonal neighbours of placed treasures.
+2. **Crab-neighbour rule**: every crab has at least one treasure among its in-bounds orthogonal neighbours. This is the basis of the solver's crab-satisfaction forcing (Pass 4).
+3. Treasures only ever appear inside fixed formation shapes, placed by **translation only** (no rotation, no reflection) — see `src/data/game/diggingFormations.js`.
 
 Tiles also carry image classes like `tileImage:pearl`, `tileImage:crab`, `tileImage:sand` for rendering.
 
@@ -149,17 +153,26 @@ A toggleable auto-solver that computes **guaranteed treasure locations** from re
 
 Parses revealed state from tile classes (sand/crab/treasure + `tileImage:` name). Revealed treasure tiles store `treasure actual-treasure` as a single space-joined class, so tokens are flattened before matching.
 
-**Algorithm — local treasure-anchored deduction (three passes, iterated until stable):**
+**Algorithm — local, treasure-anchored deduction (five passes + finalization, iterated until stable):**
 
-- **Pass 1 — treasure-anchored**: for each revealed treasure T, enumerate every legal placement of any formation shape that could cover T (translation-only, no rotation/reflection; conflicts with revealed sand/crab/wrong-name tiles are ruled out immediately). Any cell that is a treasure-plot in *every* candidate placement is guaranteed.
-- **Pass 2 — single-instance forcing**: when exactly one instance of a formation is on the board and a revealed treasure name is owned only by that shape, enumerate all legal placements of that single instance and intersect them.
-- **Pass 3 — pure elimination**: for a single-instance formation with no name-confined reveal to anchor on, enumerate all legal placements across the whole board. If only one survives (ruled out by sand/crab/edges/pseudo-reveals), its cells are guaranteed.
-- **Pass 4 (crab-satisfaction forcing):** if a revealed crab has no known treasure neighbour and exactly one eligible candidate neighbour (not sand, not crab, not sand-adjacent), that neighbour is a guaranteed treasure.
-- **Propagation**: newly guaranteed cells with an unambiguous name are promoted to `revealedTreasureName` as *pseudo-reveals* so subsequent iterations can use them as spatial constraints for other formations. The loop repeats until nothing changes.
+- **Pass 1 — treasure-anchored** (two-phase): for each revealed treasure T, enumerate every legal placement of any formation shape that could cover T (translation-only, no rotation/reflection; a placement is rejected if a plot lands on revealed sand/crab, on a differently-named revealed treasure, or orthogonally adjacent to revealed sand — the treasure-neighbour rule). Any cell that is a treasure-plot in *every* candidate placement is guaranteed. *Phase A* immediately promotes anchors with exactly one candidate (their cells are certain, and confirming them tightens later anchors); *Phase B* recomputes all candidates with those promotions applied and intersects.
+- **Instance consumption**: when an anchor (or Pass 2/3 survivor) pins a shape to exactly one placement, that instance is *confirmed* — recorded by placement signature (dedup so two dug tiles of the same instance don't double-count) and its cell-origin is locked (`committedCellOrigin`), and the shape's remaining instance count (`remainingCount`) is decremented. Once a key reaches 0, no further placements of that shape are generated, which unblocks other anchors that were ambiguous only because of the now-committed instance. Pseudo-revealed cells never consume a slot.
+- **Pass 2 — single-instance forcing**: when exactly one instance of a shape remains and a revealed treasure is *dynamically confined* to it (only that shape can explain it, considering sibling shapes already consumed), enumerate the instance's legal placements that cover all such reveals and intersect them.
+- **Pass 3 — pure elimination**: for a single-remaining instance with no confined-name reveal to anchor on, enumerate every legal placement across the whole board. If only one survives (ruled out by sand/crab/edges/pseudo-reveals), its cells are guaranteed and the instance is consumed.
+- **Pass 4 — crab-satisfaction forcing**: if a revealed crab has no known treasure neighbour and exactly one eligible candidate neighbour (not sand, not crab, not treasure, not sand-adjacent), that neighbour is a guaranteed treasure (name unknown).
+- **Pass 5 — global-consistency name disambiguation**: the local passes are sound but incomplete — a cell can be provably a treasure while its NAME is only provable via global constraints (every formation instance occurs exactly once, placements may not overlap, and every revealed treasure must be covered by exactly one placement). Live case: C4=CB + D5=OP are diagonal, so no straight-line artefact can cover both — only SEVENTEEN's L fits, making D4 provably Camel Bone even though the local passes saw disagreeing candidates. For each guaranteed-but-ambiguous cell, Pass 5 runs a **bounded exact search** (backtracking over reveals, most-constrained first; 50k-node budget) asking "does a full consistent assignment exist where this cell carries name n?" for each disputed name. Names with no consistent assignment are eliminated; exactly one survivor is the proven name, which then propagates as a pseudo-reveal so the loop re-derives the rest. Budget exhaustion or zero survivors ⇒ stays ambiguous (never a wrong name). Sound because eliminating n only claims "no consistent assignment names this cell n" — and the real board's placement is always among the enumerated ones.
+- **Propagation**: newly guaranteed cells with an unambiguous name are promoted to `revealedTreasureName` as *pseudo-reveals* so subsequent iterations can use them as spatial constraints for other formations. Cells whose name is still disputed (Pass 5 couldn't eliminate down to one) stay guaranteed-but-ambiguous — index kept, no slug emitted, deliberately **not** promoted, since treating them as a specific treasure could wrongly eliminate another shape's real placement. The loop repeats until a full iteration changes nothing.
+- **Finalization — whole-pattern guarantee** (`guaranteedFormationCounts`): the number of *individually confirmed* instances per shape (distinct confirmed signatures), plus, for a shape with exactly one remaining instance whose lone survivor wasn't already confirmed, that instance. The UI checkmarks exactly that many of the shape's thumbnails (N-of-M, not all-or-nothing).
 
-**Why local instead of global backtracking search**: the global approach is exponential and, once capped, its solution set is incomplete — intersecting an incomplete set can wrongly guarantee a tile. The local method needs no cap and is always sound (never a false positive).
+**Why local passes + a bounded global judge**: unrestricted global backtracking is exponential and, once capped, incomplete — intersecting an incomplete solution set can wrongly guarantee a tile. So the primary passes stay local (never a false positive, no cap needed). Pass 5 is the exception, and it's safe for a different reason: it never *adds* a guarantee from a partial search — it only *eliminates* a candidate name when an exhaustive (budgeted) search proves no consistent assignment exists. An exhausted budget yields no conclusion, so even a hard board can only stay ambiguous, never wrong. Every claim — positive or negative — is proven against the revealed state + the game invariants, and the 800-board soundness oracle checks them against ground truth.
 
 The solve is synchronous and instant (no cap, no idle callback needed). It is called inside `usePredictionEngine.js` which wraps it in a `watchEffect` and debounces via `requestIdleCallback` for UI responsiveness.
+
+**Return shape** — `solveTreasures(tiles, patternKeys, gridSize)` returns:
+- `guaranteed: Set<idx>` — provably treasure (includes already-revealed treasure tiles; the UI filters them for display)
+- `guaranteedSlugs: Map<idx, slug>` — treasure image slug, present only when the name is unambiguous
+- `guaranteedCandidates: Map<idx, slug[]>` — for guaranteed-but-ambiguous cells, the disputed identities the solver is still weighing (feeds the UI "?" tooltip: "could be: camel bone, otter pebble"); cleared when a name is proven
+- `guaranteedFormationCounts: Map<key, count>` — whole-pattern guarantees (see finalization)
 
 ### Testing the solver
 

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -111,7 +111,7 @@ exports.handler = async (event) => {
     logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
       statusCode: cached.statusCode,
-      headers: { ...corsHeaders, 'Cache-Control': 'public, max-age=60' },
+      headers: corsHeaders,
       body: cached.body,
     }
   }

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -27,6 +27,14 @@ function resolveApiTarget (event) {
 
 const corsHeaders = {
   'Content-Type': 'application/json',
+  // Explicit no-store: land data is dynamic per-farm, and leaving this unset
+  // lets netlify dev's fastify static layer apply its default 1h browser cache
+  // (public, max-age=3600) locally — which makes the refresh button look broken
+  // (browser serves the old body). In prod it guarantees no browser/CDN caching;
+  // the only cache is this function's 60s in-memory responseCache, which the
+  // x-sfl-bypass-cache header controls. If edge caching is ever wanted, switch
+  // to CDN-Cache-Control + Vary (see practice-patterns.cjs).
+  'Cache-Control': 'no-store',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, x-sfl-api-env, x-sfl-bypass-cache',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -111,7 +111,7 @@ exports.handler = async (event) => {
     logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
       statusCode: cached.statusCode,
-      headers: corsHeaders,
+      headers: { ...corsHeaders, 'Cache-Control': 'public, max-age=60' },
       body: cached.body,
     }
   }

--- a/src/components/Grid.vue
+++ b/src/components/Grid.vue
@@ -53,7 +53,7 @@
         <span
           v-else-if="predictionUnknown(index)"
           class="prediction-unknown"
-          title="Guaranteed treasure — exact type unknown"
+          :title="predictionUnknownTitle(index)"
         >?</span>
 
         <!-- transient shovel dig reveal overlay for freshly-dug tiles.
@@ -166,7 +166,7 @@ const picker = ref(null)
 // able to anchor to its shape. Including all shapes only ever makes deductions
 // more conservative (never a wrong guarantee).
 const { solverPatternKeys } = useLandData()
-const { guaranteed, guaranteedSlugs } = usePredictionEngine(
+const { guaranteed, guaranteedSlugs, guaranteedCandidates } = usePredictionEngine(
   tiles,
   solverPatternKeys,
   toRef(() => showPrediction),
@@ -198,6 +198,19 @@ function predictionUnknown(index) {
   if (!guaranteed.value.has(index)) return false
   if (isRevealed(tiles.value[index])) return false
   return !guaranteedSlugs.value.has(index)
+}
+
+// Explainer tooltip for the "?" — lists the candidate identities the solver is
+// still weighing (e.g. "could be Camel Bone or Otter Pebble"), so an ambiguous
+// mark reads as a sound deduction instead of a mystery. Falls back to the old
+// generic text when the solver reports no candidates for the cell.
+function predictionUnknownTitle(index) {
+  const candidates = guaranteedCandidates.value.get(index)
+  if (candidates?.length) {
+    const names = candidates.map(s => s.replace(/_/g, ' ')).join(', ')
+    return `Guaranteed treasure — could be: ${names}`
+  }
+  return 'Guaranteed treasure — exact type unknown'
 }
 
 // static labels for overlays

--- a/src/components/LandLoader.vue
+++ b/src/components/LandLoader.vue
@@ -64,7 +64,7 @@ function goToLand() {
   if (shouldAutoFetch) {
     setTimeout(() => {
       const { reloadFromServer } = useLandSync({ landId: id })
-      reloadFromServer({ landId: id, skipCooldown: true })
+      reloadFromServer({ landId: id })
     }, 300)
   }
 }

--- a/src/components/PracticeGrid.vue
+++ b/src/components/PracticeGrid.vue
@@ -67,7 +67,7 @@
           <span
             v-else-if="!tile && predictionUnknown(index)"
             class="prediction-unknown"
-            title="Guaranteed treasure — exact type unknown"
+            :title="predictionUnknownTitle(index)"
           >?</span>
 
           <!-- Confirm-dig: pulsing check waiting for second click -->
@@ -161,7 +161,7 @@ const solverTiles = computed(() =>
   })
 )
 
-const { guaranteed, guaranteedSlugs } = usePredictionEngine(
+const { guaranteed, guaranteedSlugs, guaranteedCandidates } = usePredictionEngine(
   solverTiles,
   toRef(props, 'patternKeys'),
   toRef(props, 'showPrediction'),
@@ -182,6 +182,17 @@ function predictionUnknown(index) {
   if (!props.showPrediction) return false
   if (!guaranteed.value.has(index)) return false
   return !guaranteedSlugs.value.has(index)
+}
+
+// Explainer tooltip for the "?" — lists the candidate identities the solver is
+// still weighing, so an ambiguous mark reads as a sound deduction instead of a
+// mystery. Falls back to the generic text when no candidates are reported.
+function predictionUnknownTitle(index) {
+  const candidates = guaranteedCandidates.value.get(index)
+  if (candidates?.length) {
+    return `Guaranteed treasure — could be: ${candidates.map(s => s.replace(/_/g, ' ')).join(', ')}`
+  }
+  return 'Guaranteed treasure — exact type unknown'
 }
 
 const emit = defineEmits(['dig', 'auto-finish'])

--- a/src/components/RefreshLandData.vue
+++ b/src/components/RefreshLandData.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :disabled="isLoading || isCooldown || isHistoricalView"
-    @click="reloadFromServer"
+    @click="() => reloadFromServer({ bypassCache: true })"
     class="refresh-btn btn btn-primary btn-sm sm:btn-md text-xs sm:text-sm text-nowrap text-base-100"
   >
     <span v-if="isLoading" class="loading">⏳</span>

--- a/src/composables/useApiEnvironmentSwitch.js
+++ b/src/composables/useApiEnvironmentSwitch.js
@@ -28,7 +28,7 @@ export function useApiEnvironmentSwitch () {
     if (landId) {
       setTimeout(() => {
         const { reloadFromServer } = useLandSync({ landId })
-        reloadFromServer({ landId, force: true })
+        reloadFromServer({ landId, force: true, bypassCache: true })
       }, 100)
     }
   }

--- a/src/composables/useLandSync.js
+++ b/src/composables/useLandSync.js
@@ -1,13 +1,16 @@
 // src/composables/useLandSync.js
+//
+// Thin UI wrapper over landFetchCoordinator. Owns the visible refresh state
+// (isLoading / isCooldown / remaining countdown); ALL network decisions live
+// in the coordinator (freshness, single-flight, cooldown, bypass policy).
+
 import { ref, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useLandData } from '@/composables/useLandData'
-import { fetchLandData } from '@/services/landSyncService'
+import { requestLandData } from '@/services/landFetchCoordinator'
 import { getLandCooldownStorageKey } from '@/config/api.js'
 
 const instances = new Map()
-const SUCCESS_COOLDOWN_MS = 15_000
-const FAILURE_COOLDOWN_MS = 30_000
 
 export function useLandSync (opts = {}) {
   let landId
@@ -36,6 +39,7 @@ export function useLandSync (opts = {}) {
     }
 
     function startCountdown (endTime) {
+      clearInterval(intervalId)
       isCooldown.value = true
       intervalId = setInterval(() => {
         const msLeft = endTime - Date.now()
@@ -55,40 +59,39 @@ export function useLandSync (opts = {}) {
     onBeforeUnmount(() => clearInterval(intervalId))
 
     async function reloadFromServer (opts = {}) {
-      const { force = false, skipCooldown = false, landId: overrideLandId } = opts
+      const { force = false, bypassCache = false, landId: overrideLandId } = opts
       const targetLandId = overrideLandId || landId
       if (isLoading.value || (isCooldown.value && !force)) return
 
       isLoading.value = true
 
       try {
-        const fresh = await fetchLandData(targetLandId, { bypassCache: true })
+        const data = await requestLandData(targetLandId, { force, bypassCache })
         lastFetchFailed = false
-        landData.value = {
-          date: new Date().toISOString().slice(0, 10),
-          fetchedAt: Date.now(),
-          ...fresh,
+
+        // Suppressed (cooldown active, nothing new) — keep current data as-is.
+        if (!data) return
+
+        landData.value = data
+
+        const desertDigging = data.visitedFarmState?.desert?.digging
+        const username = data.visitedFarmState?.username
+        if (desertDigging) {
+          window.dispatchEvent(
+            new CustomEvent('landDataReady', {
+              detail: { desertDigging, username },
+            }),
+          )
         }
-
-        const desertDigging = fresh.visitedFarmState.desert.digging
-        const username = fresh.visitedFarmState.username
-
-        window.dispatchEvent(
-          new CustomEvent('landDataReady', {
-            detail: { desertDigging, username },
-          }),
-        )
       } catch (err) {
         lastFetchFailed = true
         alert(err.message || 'An unexpected error occurred while loading land data.')
       } finally {
         isLoading.value = false
-
-        if (!force && !skipCooldown && !isCooldown.value) {
-          const cooldownMs = lastFetchFailed ? FAILURE_COOLDOWN_MS : SUCCESS_COOLDOWN_MS
-          const endTime = Date.now() + cooldownMs
-          localStorage.setItem(cooldownKey, String(endTime))
-          startCountdown(endTime)
+        // Re-sync the cooldown UI from the coordinator's authoritative state.
+        const end = Number(localStorage.getItem(cooldownKey))
+        if (end > Date.now()) {
+          startCountdown(end)
         }
       }
     }

--- a/src/composables/usePredictionEngine.js
+++ b/src/composables/usePredictionEngine.js
@@ -10,6 +10,7 @@ import { solveTreasures } from '@/utils/treasureSolver.js'
 export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { gridSize = 10, syncRef = null } = {}) {
   const guaranteed = ref(new Set())
   const guaranteedSlugs = ref(new Map())
+  const guaranteedCandidates = ref(new Map())
   const guaranteedFormationCounts = ref(new Map())
 
   const schedule = (typeof window !== 'undefined' && window.requestIdleCallback)
@@ -25,6 +26,7 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     const result = solveTreasures(tilesRef.value, patternKeysRef.value, gridSize)
     guaranteed.value = result.guaranteed
     guaranteedSlugs.value = result.guaranteedSlugs
+    guaranteedCandidates.value = result.guaranteedCandidates
     guaranteedFormationCounts.value = result.guaranteedFormationCounts
   }
 
@@ -34,6 +36,7 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     if (!enabledRef.value) {
       guaranteed.value = new Set()
       guaranteedSlugs.value = new Map()
+      guaranteedCandidates.value = new Map()
       guaranteedFormationCounts.value = new Map()
       return
     }
@@ -60,5 +63,5 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     { immediate: true, deep: true }
   )
 
-  return { guaranteed, guaranteedSlugs, guaranteedFormationCounts }
+  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts }
 }

--- a/src/data/game/README.md
+++ b/src/data/game/README.md
@@ -9,8 +9,9 @@ Auto-synced daily from https://github.com/sunflower-land/sunflower-land
 - `diggingFormations.js` - Treasure pattern formations (manually extracted from SFL repo)
 
 ## Updates
-- **Automatic**: Daily at 00:00 UTC via GitHub Actions
+- **Automatic**: Weekly (Sundays 00:00 UTC) via the `sync-game-data` GitHub Action; seasonal artefacts monthly (1st–3rd) via `sync-artefact`
 - **Manual**: Run `npm run sync-game-data`
+- **Both branches**: syncs commit to `master` and are mirrored to `development` automatically (file-level copy of `src/data/game/` + `public/world/`), so prod and beta always carry identical game data
 
 ## Format
 ```json

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,24 @@
+# src/services/ — network layer
+
+Every service here calls a `/api/*` Netlify proxy. One rule: **land-data requests
+must go through `landFetchCoordinator.js`**, never straight to `landApiService`.
+See [docs/API_LAYER.md](../../docs/API_LAYER.md) for the full pipeline + policy.
+
+| Service | Endpoint(s) | Purpose | Callers | Caching / dedup |
+|---|---|---|---|---|
+| `landFetchCoordinator.js` ⭐ | (none — orchestrates) | **The only door to the SFL farm API**: single-flight, 5-min localStorage freshness, cooldown, bypass policy | `useLandSync`, `PracticeDigging.vue` | single-flight per `env:landId`, localStorage TTL, 15/30s cooldown |
+| `landApiService.js` | `/.netlify/functions/sfl-api/community/farms/:id` (+ `/visit/` fallback) | Raw fetch to the SFL API proxy; prod→test env fallback; 429 mapping | `landSyncService` only (via coordinator) | none client-side (proxy has 60s cache) |
+| `landSyncService.js` | (delegates) | Thin wrapper: rethrows 429 with friendly message | `landFetchCoordinator` | none |
+| `practicePatternService.js` | `/api/practice-patterns?utcDate=` | Today's / past-date formation patterns from the hub | `usePracticePatterns` | per-day localStorage cache + single-flight (in composable) |
+| `digDayApiService.js` | `/api/dig-day` | Fetch/save dig-day snapshots (ETag + idempotent writes) | `useDigDayStore`, history views | ETag revalidation + freshness cache (see DIG_DAY_SYNC.md) |
+| `hubAuthService.js` | `/api/hub-auth` | OTP send/verify, session token | `useHubSession`, login views | none (auth) |
+| `hubProfileService.js` | `/api/hub-profile` | Hub user profile read/write | account views | none |
+| `practiceHubService.js` | `/api/practice-runs` | Submit practice runs, score settings, nickname | `PracticeDigging.vue` | none (writes) |
+| `practiceRunApiService.js` | `/api/practice-run?id=` | Fetch a single saved practice run for replay | `PracticeDigging.vue` replay | none |
+| `adminBlobService.js` | `/api/admin-blobs` | Admin blob storage (solver fixtures etc.) | `/admin` | none |
+
+Hub calls attach `Authorization: Bearer <jwt>` when a session exists — that lives
+in `src/features/hub/hubClient.js` (`hubAuthHeaders()`).
+
+Do **not** add a new service that calls the SFL farm API directly. Extend the
+coordinator instead.

--- a/src/services/landFetchCoordinator.js
+++ b/src/services/landFetchCoordinator.js
@@ -1,0 +1,125 @@
+// src/services/landFetchCoordinator.js
+//
+// The ONLY door to the Sunflower Land farm API.
+//
+// Every component/composable that needs live land data goes through
+// requestLandData() — never call fetchLandDataFromServer() directly.
+//
+// Policy (full table in docs/API_LAYER.md):
+//   - Auto loads   -> serve the localStorage cache while it is fresh
+//                     (< LAND_CACHE_FRESH_MS); otherwise fetch through the
+//                     proxy's own 60s cache (no bypass header).
+//   - User refresh -> bypassCache: true (skip freshness AND the proxy cache),
+//                     still respects the 15s cooldown.
+//   - Env switch   -> force: true (skip freshness AND cooldown).
+//   - Single-flight: concurrent requests for the same (env, landId) share one
+//     network call — same pattern as usePracticePatterns' ongoingFetch.
+//   - Every network hit (success or failure) arms the localStorage cooldown.
+
+import { fetchLandData } from '@/services/landSyncService'
+import {
+  getLandCooldownStorageKey,
+  getLandDataStorageKey,
+  isTestApiEnvironment,
+} from '@/config/api.js'
+import { LAND_CACHE_FRESH_MS } from '@/utils/landCache.js'
+
+const SUCCESS_COOLDOWN_MS = 15_000
+const FAILURE_COOLDOWN_MS = 30_000
+
+// Module-scoped single-flight map: `${env}:${landId}` -> in-flight Promise.
+const inflight = new Map()
+
+const hasWindow = () => typeof window !== 'undefined'
+const todayUTC = () => new Date().toISOString().slice(0, 10)
+
+function requestKey (landId) {
+  return `${isTestApiEnvironment() ? 'test' : 'production'}:${String(landId)}`
+}
+
+function readCacheEnvelope (landId) {
+  if (!hasWindow()) return null
+  try {
+    return JSON.parse(localStorage.getItem(getLandDataStorageKey(landId)) || 'null')
+  } catch {
+    return null
+  }
+}
+
+/** The stored envelope `{ date, fetchedAt, visitedFarmState, ... }` or null. */
+export function readLandCache (landId) {
+  return readCacheEnvelope(landId) || null
+}
+
+/** Envelope only when it is for today AND younger than maxAgeMs. */
+export function readFreshLandCache (landId, maxAgeMs = LAND_CACHE_FRESH_MS) {
+  const raw = readCacheEnvelope(landId)
+  if (!raw || raw.date !== todayUTC() || !raw.visitedFarmState) return null
+  if (!raw.fetchedAt || Date.now() - raw.fetchedAt > maxAgeMs) return null
+  return raw
+}
+
+export function isCooldownActive (landId) {
+  if (!hasWindow()) return false
+  const end = Number(localStorage.getItem(getLandCooldownStorageKey(landId)) || 0)
+  return end > Date.now()
+}
+
+function armCooldown (landId, ms) {
+  if (!hasWindow()) return
+  localStorage.setItem(getLandCooldownStorageKey(landId), String(Date.now() + ms))
+}
+
+function writeCache (landId, data) {
+  if (!hasWindow()) return
+  localStorage.setItem(
+    getLandDataStorageKey(landId),
+    JSON.stringify({ date: todayUTC(), fetchedAt: Date.now(), ...data }),
+  )
+}
+
+/**
+ * Fetch land data with dedup + freshness + cooldown policy.
+ *
+ * @param {string} landId
+ * @param {{ force?: boolean, bypassCache?: boolean }} [options]
+ * @returns {Promise<object|null>} Envelope `{ date, fetchedAt, visitedFarmState }`,
+ *   or null when the call was suppressed (cooldown active, nothing cached).
+ */
+export async function requestLandData (landId, { force = false, bypassCache = false } = {}) {
+  if (!landId) throw new Error('landId is required')
+  const key = requestKey(landId)
+
+  // 1. Fresh cache short-circuit — auto loads only. A user refresh
+  //    (bypassCache) explicitly wants to re-hit the server.
+  if (!force && !bypassCache) {
+    const fresh = readFreshLandCache(landId)
+    if (fresh) return fresh
+  }
+
+  // 2. Cooldown: suppress the network call, still serve whatever we have.
+  //    Navigation/mounts never pile requests onto a busy server.
+  if (!force && isCooldownActive(landId)) {
+    return readLandCache(landId)
+  }
+
+  // 3. Single-flight: concurrent callers share one network request.
+  if (inflight.has(key)) return inflight.get(key)
+
+  const promise = (async () => {
+    const data = await fetchLandData(landId, { bypassCache })
+    writeCache(landId, data)
+    armCooldown(landId, SUCCESS_COOLDOWN_MS)
+    return { date: todayUTC(), fetchedAt: Date.now(), ...data }
+  })()
+
+  inflight.set(key, promise)
+  try {
+    return await promise
+  } catch (err) {
+    armCooldown(landId, FAILURE_COOLDOWN_MS)
+    throw err
+  } finally {
+    inflight.delete(key)
+  }
+}

--- a/src/utils/treasureSolver.js
+++ b/src/utils/treasureSolver.js
@@ -83,12 +83,12 @@ function flattenTile(tile) {
  * @param {(string[]|string)[]} tiles - grid cells of CSS class arrays
  * @param {string[]} patternKeys - formation multiset on the board
  * @param {number} gridSize - default 10
- * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedFormationCounts: Map<string,number>, partial: boolean }}
+ * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedCandidates: Map<number,string[]>, guaranteedFormationCounts: Map<string,number>, partial: boolean }}
  */
 export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   const guaranteed = new Set()
   if (!patternKeys?.length) {
-    return { guaranteed, guaranteedSlugs: new Map(), guaranteedFormationCounts: new Map(), partial: false }
+    return { guaranteed, guaranteedSlugs: new Map(), guaranteedCandidates: new Map(), guaranteedFormationCounts: new Map(), partial: false }
   }
 
   // ── Parse revealed state ────────────────────────────────────────────
@@ -164,13 +164,31 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // can no longer say WHICH treasure — so no image is shown).
   const guaranteedNames = new Map() // idx -> display name (unambiguous so far)
   const ambiguousIdx = new Set()
+  // Disputed names for guaranteed-but-ambiguous cells, unioned across every
+  // anchor/candidate that touched the cell (idx -> Set<slug>). Pure reporting:
+  // feeds the UI's "?" tooltip with the possible identities; never influences
+  // deduction. Cleared the moment the cell is ever confirmed (see
+  // recordConfirmedPlots), at which point its name is ground truth.
+  const ambiguousCandidates = new Map()
+
+  const markAmbiguous = (idx, names) => {
+    ambiguousIdx.add(idx)
+    guaranteedNames.delete(idx)
+    let set = ambiguousCandidates.get(idx)
+    if (!set) { set = new Set(); ambiguousCandidates.set(idx, set) }
+    for (const n of names) set.add(normName(n))
+  }
 
   const recordName = (idx, name) => {
-    if (ambiguousIdx.has(idx)) return
+    if (ambiguousIdx.has(idx)) {
+      // Keep accumulating the possible identities for reporting — a cell can
+      // be touched by several anchors, each adding a candidate name.
+      ambiguousCandidates.get(idx)?.add(normName(name))
+      return
+    }
     if (guaranteedNames.has(idx)) {
       if (!namesMatch(guaranteedNames.get(idx), name)) {
-        guaranteedNames.delete(idx)
-        ambiguousIdx.add(idx)
+        markAmbiguous(idx, [guaranteedNames.get(idx), name])
       }
     } else {
       guaranteedNames.set(idx, name)
@@ -188,7 +206,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       guaranteed.add(idx)
       const names = new Set(candidates.map(c => normName(c.get(idx))))
       if (names.size === 1) recordName(idx, first.get(idx))
-      else { guaranteedNames.delete(idx); ambiguousIdx.add(idx) }
+      else markAmbiguous(idx, names)
     }
   }
 
@@ -205,10 +223,22 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // can never later contradict themselves (committedCellOrigin locks an idx
   // to its first-confirmed origin forever), so overriding a stale ambiguous
   // mark here is always safe.
+  // Collects the placements of CONFIRMED instances (deduped by signature), so
+  // the global-consistency search (Pass 5) can treat them as fixed ground
+  // truth rather than re-solving them.
+  const confirmedPlacements = []
+  const confirmedPlacementSet = new Set()
+
   const recordConfirmedPlots = (plots) => {
+    const sig = placementSignature(plots)
+    if (!confirmedPlacementSet.has(sig)) {
+      confirmedPlacementSet.add(sig)
+      confirmedPlacements.push(plots)
+    }
     for (const [idx, name] of plots) {
       guaranteed.add(idx)
       ambiguousIdx.delete(idx)
+      ambiguousCandidates.delete(idx)
       guaranteedNames.set(idx, name)
     }
   }
@@ -308,6 +338,25 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     return cands.length > 0 && cands.every(c => c.key === key)
   }
 
+  // Enumerate every still-legal placement of `key` across the whole board
+  // (multi-remaining-instance shapes use this — the global-consistency search
+  // picks N pairwise non-overlapping placements from it).
+  const enumerateAllPlacements = (key) => {
+    const formation = DIGGING_FORMATIONS[key]
+    const minX = Math.min(...formation.map(p => p.x))
+    const maxX = Math.max(...formation.map(p => p.x))
+    const minY = Math.min(...formation.map(p => p.y))
+    const maxY = Math.max(...formation.map(p => p.y))
+    const allPlacements = []
+    for (let oy = -minY; oy <= gridSize - 1 - maxY; oy++) {
+      for (let ox = -minX; ox <= gridSize - 1 - maxX; ox++) {
+        const plots = buildPlacement(formation, ox, oy)
+        if (plots) allPlacements.push(plots)
+      }
+    }
+    return allPlacements
+  }
+
   // Enumerate every still-legal placement of a single-instance formation
   // `key`, against whatever `revealedTreasureName` holds at call time. If a
   // revealed (or pseudo-revealed) treasure name is (dynamically) confined to
@@ -335,19 +384,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       return survivors
     }
 
-    const minX = Math.min(...formation.map(p => p.x))
-    const maxX = Math.max(...formation.map(p => p.x))
-    const minY = Math.min(...formation.map(p => p.y))
-    const maxY = Math.max(...formation.map(p => p.y))
-
-    const allPlacements = []
-    for (let oy = -minY; oy <= gridSize - 1 - maxY; oy++) {
-      for (let ox = -minX; ox <= gridSize - 1 - maxX; ox++) {
-        const plots = buildPlacement(formation, ox, oy)
-        if (plots) allPlacements.push(plots)
-      }
-    }
-    return allPlacements
+    return enumerateAllPlacements(key)
   }
 
   // ── Iterative deduction ──────────────────────────────────────────────
@@ -575,6 +612,181 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       }
     }
 
+    // ── Pass 5: global-consistency name disambiguation ───────────────────
+    // The per-anchor local passes are sound but incomplete: a cell can be
+    // provably a treasure while its NAME is only provable via global
+    // constraints — every formation instance occurs exactly once, placements
+    // may not overlap, and every revealed treasure must be covered by exactly
+    // one placement. Live case: C4=CB + D5=OP are diagonal, so no straight-line
+    // artefact (FIFTEEN/TWENTY_FOUR) can cover both — only SEVENTEEN's L can —
+    // hence D4 is provably Camel Bone even though the local passes saw
+    // disagreeing candidates. For each disputed name, run a bounded exact
+    // search for a full consistent assignment in which the cell carries that
+    // name; names with NO consistent assignment are eliminated.
+    //
+    // Soundness: the real board's placement of every remaining instance is one
+    // of the enumerated legal placements, so "no consistent assignment with
+    // name n at cell X" ⇒ the real board does not name X=n ⇒ eliminating n is
+    // sound. The search checks placement legality (buildPlacement), non-overlap
+    // and reveal coverage; it deliberately ignores crab-satisfaction — a more
+    // permissive search can only KEEP names it shouldn't (cell stays
+    // ambiguous), never eliminate a real one. Budget exhaustion yields no
+    // conclusion (stays ambiguous — never a wrong name).
+    if (ambiguousCandidates.size) {
+      const groups = []
+      let groupsValid = true
+      for (const key of presentKeys) {
+        const need = remainingCount.get(key) ?? 0
+        if (need === 0) continue
+        const placements = need === 1
+          ? enumerateSingleInstanceSurvivors(key)
+          : enumerateAllPlacements(key)
+        if (!placements.length || placements.length < need) { groupsValid = false; break }
+        groups.push({ key, need, placements })
+      }
+      // Most-constrained first: fewest placement options → fewest branches.
+      groups.sort((a, b) => a.placements.length - b.placements.length)
+
+      const BUDGET = Symbol('budget')
+      const fixedCovered = new Set()
+      for (const plots of confirmedPlacements) {
+        for (const idx of plots.keys()) fixedCovered.add(idx)
+      }
+
+      // Find ANY full assignment (fixed placements + one non-overlapping
+      // placement per remaining instance) covering every revealed treasure
+      // cell. `extraReveals` adds a hypothetical reveal (cell → name) so we
+      // can test "could this cell be name n?". Returns true/false, or null on
+      // budget.
+      //
+      // Search strategy — backtrack over REVEALS, most-constrained first
+      // (a reveal with 1-2 covering placements prunes the tree far harder
+      // than a shape with 50 free placements), with sound reductions:
+      //  - a placement that CONTAINS a reveal cell but names it wrongly is
+      //    invalid (matters for the hypothetical extra reveals — the real
+      //    ones are already enforced by buildPlacement);
+      //  - shapes that end up covering no reveal ("floated") only need SOME
+      //    non-overlapping placement to exist — checked once at the leaf.
+      const search = (extraReveals) => {
+        const revealName = new Map(revealedTreasureName)
+        for (const [idx, name] of extraReveals) revealName.set(idx, name)
+
+        // Per-group precomputation: placement conflict flags (extra reveals
+        // only — regular ones are guaranteed clean by buildPlacement).
+        const groupPlacementOk = groups.map(g => g.placements.map(p => {
+          for (const [eIdx, eName] of extraReveals) {
+            const n = p.get(eIdx)
+            if (n !== undefined && !namesMatch(n, eName)) return false
+          }
+          return true
+        }))
+
+        // Options per reveal: which (group, placement) can cover it correctly.
+        const options = new Map()
+        for (const [idx, name] of revealName) {
+          if (fixedCovered.has(idx)) continue
+          const opts = []
+          for (let gi = 0; gi < groups.length; gi++) {
+            const { placements } = groups[gi]
+            for (let pi = 0; pi < placements.length; pi++) {
+              const n = placements[pi].get(idx)
+              if (n !== undefined && namesMatch(n, name) && groupPlacementOk[gi][pi]) {
+                opts.push([gi, pi])
+              }
+            }
+          }
+          options.set(idx, opts)
+        }
+
+        const slots = groups.map(g => g.need)
+        const placed = []
+        const occupied = new Set(fixedCovered)
+        const covered = new Set(fixedCovered)
+        let nodes = 0
+
+        const uncoveredReveals = () => {
+          const out = []
+          for (const idx of revealName.keys()) {
+            if (!covered.has(idx)) out.push(idx)
+          }
+          return out
+        }
+
+        const floatsOk = () => {
+          for (let gi = 0; gi < groups.length; gi++) {
+            if (slots[gi] === 0) continue
+            const { placements } = groups[gi]
+            let ok = false
+            for (let pi = 0; pi < placements.length; pi++) {
+              if (!groupPlacementOk[gi][pi]) continue
+              if (![...placements[pi].keys()].some(idx => occupied.has(idx))) { ok = true; break }
+            }
+            if (!ok) return false
+          }
+          return true
+        }
+
+        const bt = () => {
+          if (++nodes > 50000) throw BUDGET
+          const uncovered = uncoveredReveals()
+          if (!uncovered.length) return floatsOk()
+
+          // Most-constrained reveal first: fewest live options.
+          let best = null
+          for (const idx of uncovered) {
+            const live = options.get(idx).filter(([gi]) => slots[gi] > 0)
+            if (!live.length) return false // a reveal nobody can cover → dead end
+            if (!best || live.length < best.live.length) best = { idx, live }
+          }
+          const { idx, live } = best
+
+          for (const [gi, pi] of live) {
+            const p = groups[gi].placements[pi]
+            if ([...p.keys()].some(i => occupied.has(i))) continue
+            // Apply: occupy, cover, consume a slot of group gi.
+            const pKeys = [...p.keys()]
+            for (const i of pKeys) occupied.add(i)
+            for (const i of pKeys) covered.add(i)
+            slots[gi] -= 1
+            placed.push(p)
+            if (bt()) return true
+            placed.pop()
+            slots[gi] += 1
+            for (const i of pKeys) covered.delete(i)
+            for (const i of pKeys) occupied.delete(i)
+          }
+          return false
+        }
+
+        try { return bt() } catch (e) {
+          if (e === BUDGET) return null
+          throw e
+        }
+      }
+
+      const toResolve = [...ambiguousCandidates.keys()]
+      for (const idx of toResolve) {
+        const names = [...ambiguousCandidates.get(idx)]
+        const possible = []
+        let budgetHit = false
+        for (const n of names) {
+          const ok = search(new Map([[idx, n]]))
+          if (ok === true) possible.push(n)
+          else if (ok === null) { budgetHit = true; break }
+        }
+        if (budgetHit) continue // no conclusions this iteration — stay conservative
+        if (possible.length === 1) {
+          // Exactly one disputed name survives global consistency → provable.
+          guaranteedNames.set(idx, possible[0])
+          ambiguousCandidates.delete(idx)
+          ambiguousIdx.delete(idx)
+          iterChanged = true
+        }
+        // possible.length === 0 → the revealed state contradicts the game
+        // rules; keep ambiguous rather than manufacture a name.
+      }
+    }
+
     // Promote newly-guaranteed, unambiguously-named cells into
     // revealedTreasureName so the next iteration can use them as spatial
     // constraints for other formations (e.g. a single-instance shape whose
@@ -594,6 +806,14 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   const guaranteedSlugs = new Map()
   for (const [idx, name] of guaranteedNames) {
     guaranteedSlugs.set(idx, slugify(name))
+  }
+
+  // Disputed-name reporting for guaranteed-but-ambiguous cells (UI "?" tooltip):
+  // idx -> possible treasure slugs, unioned across every candidate that touched
+  // the cell. Absent for named cells. Read-only info — never used in deduction.
+  const guaranteedCandidates = new Map()
+  for (const [idx, names] of ambiguousCandidates) {
+    guaranteedCandidates.set(idx, [...names])
   }
 
   // ── Whole-pattern-guarantee finalization ────────────────────────────
@@ -624,5 +844,5 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     if (count > 0) guaranteedFormationCounts.set(key, count)
   }
 
-  return { guaranteed, guaranteedSlugs, guaranteedFormationCounts, partial: false }
+  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts, partial: false }
 }

--- a/src/views/Digging.vue
+++ b/src/views/Digging.vue
@@ -260,7 +260,7 @@ onMounted(async () => {
     const { shouldAutoFetch } = readLandCacheMeta(routeLandId)
     if (shouldAutoFetch) {
       const { reloadFromServer } = useLandSync({ landId: routeLandId })
-      reloadFromServer({ landId: routeLandId, skipCooldown: true })
+      reloadFromServer({ landId: routeLandId })
     }
   }
 })

--- a/src/views/PracticeDigging.vue
+++ b/src/views/PracticeDigging.vue
@@ -233,7 +233,7 @@ import PracticePatterns from '@/components/PracticePatterns.vue'
 import InfoFooter from '@/components/InfoFooter.vue'
 import { submitPracticeRun, isPracticeSaveScoresEnabled, setPracticeSaveScoresEnabled, getNickname, setNickname } from '@/services/practiceHubService.js'
 import { fetchPracticeRun } from '@/services/practiceRunApiService.js'
-import { fetchLandDataFromServer } from '@/services/landApiService.js'
+import { requestLandData } from '@/services/landFetchCoordinator'
 import { getTodayUTC } from '@/utils/buildDigTimeline.js'
 import { buildPracticeDigTimeline } from '@/utils/buildPracticeDigTimeline.js'
 import { encodeBoard, decodeBoard } from '@/utils/practiceBoardCode.js'
@@ -592,7 +592,8 @@ async function startLandRound (landId) {
   todayRoundErrorMessage.value = ''
   lastRunId.value = null
   try {
-    const data = await fetchLandDataFromServer(landId)
+    const data = await requestLandData(landId)
+    if (!data) throw new Error('Land data is not available right now. Please try again shortly.')
     const patterns = data?.visitedFarmState?.desert?.digging?.patterns || []
     if (!patterns.length) throw new Error('No patterns found for that land.')
     isReplayMode.value = false

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -820,6 +820,120 @@ describe('Pass 4 — crab-satisfaction forcing', () => {
   })
 })
 
+// ── Guaranteed-but-ambiguous reporting (guaranteedCandidates) ─────────────────
+// A cell can be provably a treasure while its exact NAME stays underdetermined:
+// distinct legal placements that all cover it disagree on what it's called.
+// The solver reports the disputed identities (for the UI's "?" tooltip) without
+// ever guessing. Regression: the live land 4485248732423974 case — C4/D5 are
+// revealed (Camel Bone / Otter Pebble), and three artefact formations all have
+// a legal placement through C4-D4, disagreeing on D4.
+describe('guaranteedCandidates — disputed-name reporting', () => {
+  it('D4 is guaranteed but reports the two names still in dispute', () => {
+    // C4 (idx 32) = Camel Bone, D5 (idx 43) = Otter Pebble. Crabs at B4 and C3
+    // kill every OTHER placement that could explain C4 (the FIFTEEN/TWENTY_FOUR
+    // line-origins through B4, TWENTY_FOUR's C3 variant), leaving exactly three
+    // legal explanations of the C4-D4-D5 cluster:
+    //   FIFTEEN @ (2,3):     C4=CB, D4=OP, E4=CB
+    //   TWENTY_FOUR @ (2,3): C4=CB, D4=OP, E4=CB, C5=CB, E5=CB
+    //   SEVENTEEN @ (2,3):   C4=CB, D4=CB, D5=OP
+    // All three cover D4, but name it differently → guaranteed + ambiguous.
+    const tiles = makeTiles([
+      { x: 2, y: 3, items: { 'Camel Bone': 1 } },   // C4 (idx 32)
+      { x: 3, y: 4, items: { 'Otter Pebble': 1 } }, // D5 (idx 43)
+      { x: 1, y: 3, items: { Crab: 1 } },           // B4 (idx 31)
+      { x: 2, y: 2, items: { Crab: 1 } },           // C3 (idx 22)
+    ])
+    const { guaranteed, guaranteedSlugs, guaranteedCandidates } = solveTreasures(
+      tiles, ['ARTEFACT_FIFTEEN', 'ARTEFACT_TWENTY_FOUR', 'ARTEFACT_SEVENTEEN'], G,
+    )
+
+    // The unambiguous cells keep their names…
+    expect(guaranteedSlugs.get(32), 'C4 — all candidates agree Camel Bone').toBe('camel_bone')
+    expect(guaranteedSlugs.get(43), 'D5 — all candidates agree Otter Pebble').toBe('otter_pebble')
+
+    // …and D4 is guaranteed, nameless, with both disputed identities reported.
+    expect(guaranteed.has(33), 'D4 guaranteed treasure').toBe(true)
+    expect(guaranteedSlugs.has(33), 'D4 not in guaranteedSlugs').toBe(false)
+    const candidates = guaranteedCandidates.get(33) || []
+    expect([...candidates].sort()).toEqual(['camel bone', 'otter pebble'])
+
+    // Named cells must NOT appear in the candidates map (no stale ambiguity).
+    expect(guaranteedCandidates.has(32)).toBe(false)
+    expect(guaranteedCandidates.has(43)).toBe(false)
+  })
+
+  it('global consistency resolves D4 = Camel Bone (live land 4485248732423974 case)', () => {
+    // Same C4/D5/B4/C3 cluster as the ambiguous mini-board above, PLUS the
+    // third artefact cluster G9=Otter Pebble + H9=Camel Bone. Now the name is
+    // provable GLOBALLY, even though the local passes still see two legal
+    // explanations for D4:
+    //   - D4=Otter Pebble would force FIFTEEN(2,3) or TWENTY_FOUR(2,3) at
+    //     C4-D4-E4; the remaining shapes then cannot cover BOTH the D5 reveal
+    //     AND the G9/H9 cluster without overlapping or running out of
+    //     formations (each artefact occurs exactly once).
+    //   - D4=Camel Bone is satisfied by SEVENTEEN(2,3) (C4-D4-D5) with
+    //     FIFTEEN(6,1) at G2-H2-I2 and TWENTY_FOUR(5,8) at F9-G9-H9-F10-H10.
+    // So only the Camel Bone name survives a full-consistency check.
+    const tiles = makeTiles([
+      { x: 2, y: 3, items: { 'Camel Bone': 1 } },   // C4 (idx 32)
+      { x: 3, y: 4, items: { 'Otter Pebble': 1 } }, // D5 (idx 43)
+      { x: 1, y: 3, items: { Crab: 1 } },           // B4 (idx 31)
+      { x: 2, y: 2, items: { Crab: 1 } },           // C3 (idx 22)
+      { x: 6, y: 8, items: { 'Otter Pebble': 1 } }, // G9 (idx 86)
+      { x: 7, y: 8, items: { 'Camel Bone': 1 } },   // H9 (idx 87)
+    ])
+    const { guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts } = solveTreasures(
+      tiles, ['ARTEFACT_FIFTEEN', 'ARTEFACT_TWENTY_FOUR', 'ARTEFACT_SEVENTEEN'], G,
+    )
+
+    expect(guaranteedSlugs.get(33), 'D4 — provably Camel Bone via global consistency').toBe('camel_bone')
+    expect(guaranteedCandidates.has(33), 'D4 no longer disputed').toBe(false)
+    // The resolved name propagates: SEVENTEEN becomes whole-pattern-guaranteed.
+    expect(guaranteedFormationCounts.get('ARTEFACT_SEVENTEEN')).toBe(1)
+  })
+
+  it('confirmed instances clear the candidate report (stale ambiguity overridden)', () => {
+    // Same board as the 2026-08-01 regression: once a cell is pinned to a
+    // specific instance, its name is ground truth and any earlier dispute must
+    // vanish from the report.
+    const tiles = makeTiles([
+      { x: 8, y: 8, items: { 'Camel Bone': 1 } },
+      { x: 7, y: 8, items: { [SEASONAL]: 1 } },
+      { x: 1, y: 8, items: { Crab: 1 } },
+      { x: 2, y: 8, items: { 'Cockle Shell': 1 } },
+      { x: 3, y: 9, items: { 'Cockle Shell': 1 } },
+      { x: 1, y: 1, items: { 'Camel Bone': 1 } },
+      { x: 2, y: 1, items: { 'Camel Bone': 1 } },
+      { x: 1, y: 0, items: { [SEASONAL]: 1 } },
+      { x: 8, y: 1, items: { Sand: 2 } },
+      { x: 5, y: 1, items: { Sand: 2 } },
+      { x: 8, y: 4, items: { Crab: 1 } },
+      { x: 7, y: 4, items: { Crab: 1 } },
+      { x: 8, y: 5, items: { 'Camel Bone': 1 } },
+      { x: 7, y: 5, items: { 'Cockle Shell': 1 } },
+      { x: 9, y: 6, items: { [SEASONAL]: 1 } },
+      { x: 1, y: 3, items: { Crab: 1 } },
+      { x: 1, y: 4, items: { Sand: 2 } },
+      { x: 2, y: 3, items: { Wood: 1 } },
+      { x: 3, y: 3, items: { 'Wooden Compass': 1 } },
+      { x: 4, y: 7, items: { Sand: 2 } },
+      { x: 5, y: 5, items: { Crab: 1 } },
+      { x: 4, y: 5, items: { Hieroglyph: 1 } },
+    ])
+    const patterns = [
+      'ARTEFACT_SEVENTEEN', 'ARTEFACT_FIFTEEN', 'ARTEFACT_EIGHTEEN',
+      'HIEROGLYPH', 'COCKLE', 'COCKLE', 'WOODEN_COMPASS',
+    ]
+    const tilesArr = tiles
+    const { guaranteed, guaranteedSlugs, guaranteedCandidates } = solveTreasures(tilesArr, patterns, G)
+    expect(guaranteed.has(2), 'C1 (idx 2)').toBe(true)
+    expect(guaranteedSlugs.get(2)).toBe('camel_bone')
+    // Confirmed instance ⇒ name is ground truth ⇒ nothing disputed to report.
+    expect(guaranteedCandidates.has(2), 'C1 candidates cleared after confirmation').toBe(false)
+    expect(guaranteedCandidates.has(86), 'G9 candidates cleared after confirmation').toBe(false)
+  })
+})
+
 import { SOLVER_SCENARIOS } from '@/dev/solverScenarios.js'
 
 describe('SOLVER_SCENARIOS auto-generated regression suite', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,15 @@ export default defineConfig(({ mode }) => {
     }
   },
   server: {
+    // Listen on all interfaces so the dev server is reachable from other
+    // tailnet devices, e.g. http://minipc.bongo-major.ts.net:5173 (Vite
+    // proxies /api and /.netlify/functions to the local Netlify functions
+    // below, so the full stack works without exposing netlify dev itself).
+    host: true,
+    // Vite 6 blocks Host headers not in its allowlist (raw IPs pass, hostnames
+    // like the tailnet MagicDNS name get 403). This is a private dev server —
+    // allow any hostname. LAN .local names, tailnet names, whatever.
+    allowedHosts: true,
     proxy: {
       // Local Netlify functions (hub-auth not on remote beta site)
       '/api/hub-auth': {


### PR DESCRIPTION
Documents the sync behavior shipped in #120.

- **AGENTS.md**: sync workflows push to `master` then mirror data files to `development` (file-level copy — no fast-forward requirement, no merge conflicts); corrected the game-data schedule from daily to weekly (Sundays 00:00 UTC).
- **SEASON_UPDATE_GUIDE.md**: accurate automation description (commit to master + mirror to development), corrected schedule (1st–3rd), corrected the workflow name for manual trigger, and added an explicit warning: do **not** manually run the workflow from `development` — it commits to the branch it runs on and would skip `master` entirely.
- **src/data/game/README.md**: corrected schedule + documented both-branches behavior.

Docs-only change.