### PR TITLE
feat: coordinate SFL API land-data requests (single-flight + freshness + cooldown)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Read in this order; each doc is kept accurate. If anything here conflicts with o
 | **AGENTS.md** (this file) | Dev commands, conventions, env, API-proxy quirks, dead-code register |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Full architecture: directories, routes, startup, data flow, composables/services, grid-builders, entrypoints, `src_other` |
 | [docs/GRID_MECHANICS.md](docs/GRID_MECHANICS.md) | The 10×10 grid engine: tiles, hints, formations, practice mode |
+| [docs/API_LAYER.md](docs/API_LAYER.md) | **Request pipeline + caching policy for the SFL farm API** — read before touching anything that fetches land data |
 | [docs/DIG_DAY_SYNC.md](docs/DIG_DAY_SYNC.md) | Dig-day Hub sync: debounce, ETag, merge-by-seq, the layers |
 | [docs/HUB_CONSUMPTION_SPEC.md](docs/HUB_CONSUMPTION_SPEC.md) | Hub-side ETag/idempotency contract |
 | [netlify/functions/README.md](netlify/functions/README.md) | Per-function reference for the `.cjs` proxies |
@@ -133,7 +134,8 @@ Both sync workflows commit + push to `master`, then **mirror the data files to `
 
 ## API proxy details
 
-- `sfl-api.cjs` has a 60s in-memory cache for 200 responses. Bypass with `x-sfl-bypass-cache: 1` header or `?bypassCache=1` — the app sends this on every land sync.
+- `sfl-api.cjs` has a 60s in-memory cache for 200 responses. Bypass with `x-sfl-bypass-cache: 1` header or `?bypassCache=1` — the app sends this **only** on explicit user refreshes and env switches (see [docs/API_LAYER.md](docs/API_LAYER.md)); auto loads go through the proxy cache.
+- **All land-data requests go through `src/services/landFetchCoordinator.js`** (single-flight, 5-min localStorage freshness, cooldown). Never call `fetchLandDataFromServer()` from a component.
 - `/visit/*` often returns 401 for third-party tools. The app uses `/community/farms/*` as primary and `/visit/*` as fallback only.
 - Prod/test API switching is communicated via `x-sfl-api-env` header. Land data cache keys are prefixed per-environment (`landData_` vs `landData_test_`).
 - Practice patterns are CDN-cached until UTC midnight (`CDN-Cache-Control` headers).

--- a/docs/API_LAYER.md
+++ b/docs/API_LAYER.md
@@ -28,7 +28,8 @@ landSyncService / landApiService (src/services/*.js)   ← pure fetch, error map
    │  prod → test env fallback, 429 message mapping
    ▼
 Netlify proxy  sfl-api.cjs (netlify/functions/sfl-api.cjs)   ← server-side key,
-   │  60s in-memory cache, bypassable via x-sfl-bypass-cache
+   │  60s in-memory cache, bypassable via x-sfl-bypass-cache;
+   │  responds Cache-Control: no-store → no browser/CDN HTTP caching
    ▼
 Sunflower Land public API (api.sunflower-land.com | api-dev.sunflower-land.com)
 ```
@@ -59,10 +60,20 @@ ETag + freshness cache + force flag. See [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md).
 | Coordinator single-flight | in-flight Promise per `env:landId` | duration of request | — (shared by design) |
 | localStorage cache (`landData_<env>_<id>`) | `{ date, fetchedAt, visitedFarmState }` | until UTC date changes; "fresh" while < `LAND_CACHE_FRESH_MS` (5 min) | `force: true` or `bypassCache: true` |
 | Cooldown (`landCooldownEnd_<env>_<id>`) | timestamp | 15s after success, 30s after failure | `force: true` only |
+| Browser HTTP cache | **disabled** — `sfl-api.cjs` sends `Cache-Control: no-store` on every response | never | — (by design; see golden rule 5) |
 
 Cache keys are env-prefixed (`landData_` vs `landData_test_`) so prod and test
 snapshots never mix — see `getLandDataStorageKey()` / `getLandCooldownStorageKey()`
 in `src/config/api.js`.
+
+**Netlify CDN / edge caching is deliberately NOT used for land data.** The only
+place edge caching exists is `practice-patterns.cjs` (`CDN-Cache-Control` until
+UTC midnight) — appropriate because daily patterns are immutable within a day.
+Land data is per-farm and changes as the player digs, so the 60s in-memory
+proxy cache is the outermost cache it gets. (History: the in-memory cache came
+first — `8254d9c` — and the bypass header `61272c1` exists because refreshes
+must stay fresh; the coordinator is what finally routes auto loads *through*
+the cache.)
 
 ## Policy table (`requestLandData(landId, { force, bypassCache })`)
 
@@ -103,3 +114,9 @@ only for explicit refreshes.
    neither checked nor set it, so repeated navigation fired unthrottled API calls.
 4. **Freshness is advisory unless enforced.** `landCache.js` computed
    `shouldAutoFetch` for years, but callers fired anyway. The coordinator enforces it.
+5. **"Refresh Data" never touches a cache.** The whole chain is cache-proof:
+   `bypassCache: true` skips the localStorage freshness check AND the proxy's
+   in-memory cache; `sfl-api.cjs` responds `Cache-Control: no-store` so the
+   browser HTTP cache can never serve land data; the button is disabled during
+   the 15s cooldown (no silent no-op). If a refresh ever shows data you've seen
+   before, that's a bug — every cache layer must be bypassable.

--- a/docs/API_LAYER.md
+++ b/docs/API_LAYER.md
@@ -1,0 +1,105 @@
+# API Layer
+
+> Canonical reference for how **sfl-crab / d1g.uk** talks to the Sunflower Land farm API and the Digging Hub. Read this before touching anything that fetches land data. It documents the **request pipeline, every trigger point, every caching layer, and the bypass/cooldown policy** — the stuff that used to be scattered across six files.
+
+## The one rule
+
+> **Never call `fetchLandDataFromServer()` from a component or composable.**
+> All land-data requests go through `requestLandData()` in
+> `src/services/landFetchCoordinator.js`. If you find a direct call, it's a bug.
+
+## Request pipeline (land data)
+
+```
+Component / view
+   │  e.g. Digging.vue onMounted, LandLoader, RefreshLandData,
+   │       PracticeDigging "start round", useApiEnvironmentSwitch
+   ▼
+useLandSync (src/composables/useLandSync.js)     ← UI state only
+   │  isLoading / isCooldown / remaining countdown, dispatch landDataReady
+   ▼
+landFetchCoordinator (src/services/landFetchCoordinator.js)   ← ALL decisions
+   │  1. fresh localStorage cache?   → return, zero network
+   │  2. cooldown active?            → serve stale cache, zero network
+   │  3. in-flight same (env,land)?  → join it (single-flight)
+   │  4. else fetch + write cache + arm cooldown
+   ▼
+landSyncService / landApiService (src/services/*.js)   ← pure fetch, error mapping
+   │  prod → test env fallback, 429 message mapping
+   ▼
+Netlify proxy  sfl-api.cjs (netlify/functions/sfl-api.cjs)   ← server-side key,
+   │  60s in-memory cache, bypassable via x-sfl-bypass-cache
+   ▼
+Sunflower Land public API (api.sunflower-land.com | api-dev.sunflower-land.com)
+```
+
+## Every trigger point (what fires a request)
+
+| Trigger | Caller | Mode | Result |
+|---|---|---|---|
+| Land page mounts, cache stale (>5 min) | `Digging.vue` onMounted | auto | 1 network call (single-flight with LandLoader) |
+| Land selected via LandLoader | `LandLoader.vue` goToLand | auto | joins the mount's request — never a second call |
+| User clicks "Refresh Data" | `RefreshLandData.vue` | `bypassCache: true` | fresh from SFL API, respects 15s cooldown (button disabled during it) |
+| Prod ↔ testnet switch | `useApiEnvironmentSwitch` | `force: true, bypassCache: true` | fresh from the other server, skips cooldown |
+| Practice "today's round" on a land | `PracticeDigging.vue` startLandRound | auto | reuses the digging page's cache if fresh |
+| Practice patterns (hub) | `usePracticePatterns` | auto | separate path — own single-flight + daily cache, see below |
+
+The **practice patterns** path (`/api/practice-patterns` via `practicePatternService.js`)
+is separate: it has its own single-flight (`ongoingFetch` + `window[...]` key in
+`usePracticePatterns.js`) and a per-day localStorage cache. Leave it alone.
+
+The **dig-day hub** path (`digDayApiService.js`) is also separate and already good:
+ETag + freshness cache + force flag. See [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md).
+
+## Caching layers (land data)
+
+| Layer | What it holds | Lifetime | Bypassed by |
+|---|---|---|---|
+| Proxy in-memory cache (`sfl-api.cjs`) | last 200 response per `env:path` | 60s | `bypassCache: true` (user refresh, env switch) |
+| Coordinator single-flight | in-flight Promise per `env:landId` | duration of request | — (shared by design) |
+| localStorage cache (`landData_<env>_<id>`) | `{ date, fetchedAt, visitedFarmState }` | until UTC date changes; "fresh" while < `LAND_CACHE_FRESH_MS` (5 min) | `force: true` or `bypassCache: true` |
+| Cooldown (`landCooldownEnd_<env>_<id>`) | timestamp | 15s after success, 30s after failure | `force: true` only |
+
+Cache keys are env-prefixed (`landData_` vs `landData_test_`) so prod and test
+snapshots never mix — see `getLandDataStorageKey()` / `getLandCooldownStorageKey()`
+in `src/config/api.js`.
+
+## Policy table (`requestLandData(landId, { force, bypassCache })`)
+
+| Caller intent | force | bypassCache | Fresh cache? | Cooldown? | Network? |
+|---|---|---|---|---|---|
+| Auto load (mount, navigation, practice round) | false | false | served | suppresses call | only if cache stale AND no cooldown |
+| User "Refresh Data" | false | true | skipped | respected | yes (through proxy cache bypass) |
+| Env switch | true | true | skipped | skipped | yes |
+
+Notes:
+- **Auto ≠ bypass.** Auto loads intentionally pass through the proxy cache — a
+  repeat visit inside 60s is served by the proxy, not the SFL API.
+- **Every network hit arms the cooldown**, including auto fetches. This is what
+  stops navigation spam: mount → fetch → 15s window where remounts serve cache.
+- `force` is reserved for the env switch. If you're tempted to use it elsewhere,
+  you're probably trying to work around a policy bug — fix the policy instead.
+
+## localStorage keys
+
+All land-data keys live in `src/config/api.js` (builders) and
+`src/constants/storageKeys.js` (fixed keys). Same for every other app key.
+
+## Observability
+
+The proxy logs one line per request: `sfl-api { env, path, landId, status, cache }`
+where cache ∈ `hit | miss | bypass`. In the Netlify function logs you can verify
+the policy is working: auto reloads inside 60s should show `hit` or `bypass`
+only for explicit refreshes.
+
+## Golden rules (why they exist)
+
+1. **Single door to the SFL API** — dedup and cooldown only work if every caller
+   goes through the coordinator. A direct call (the old `PracticeDigging.vue:595`)
+   silently bypasses everything.
+2. **Auto loads serve cache, refreshes force.** The proxy cache exists to absorb
+   repeat traffic; `bypassCache` on every sync (the old behavior) made it dead.
+3. **Cooldown is armed on every network hit.** Old `skipCooldown: true` callers
+   neither checked nor set it, so repeated navigation fired unthrottled API calls.
+4. **Freshness is advisory unless enforced.** `landCache.js` computed
+   `shouldAutoFetch` for years, but callers fired anyway. The coordinator enforces it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,11 +130,13 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 
 ## Data flow (live land)
 
-1. **Fetch** — `landApiService.js` → `/.netlify/functions/sfl-api/community/farms/:id` → SFL API. The app sends `bypassCache` to skip the proxy's own 60s cache on manual syncs.
+> Full request pipeline + caching policy: see [API_LAYER.md](./API_LAYER.md).
+
+1. **Fetch** — every caller goes through `landFetchCoordinator.js` (`requestLandData()`), which applies single-flight, a 5-min localStorage freshness check, and the cooldown policy. It calls `landSyncService` → `landApiService.js` → `/.netlify/functions/sfl-api/community/farms/:id` → SFL API.
 2. **Response shape** — `{ visitedFarmState: { desert: { digging: { grid, patterns, completedPatterns } } } }`. Grid tiles are `{ x, y, items: { Crab | Sand | <TreasureName> }, dugAt, tool }`.
 3. **Store** — `useLandData.js` holds reactive land data + localStorage cache, keyed per land + API env, UTC-date-stamped (stale after the UTC date changes).
 4. **Render** — `useGridEngine.js` converts API tiles → CSS class arrays and rebuilds neighbor hints (`near-*`). See [GRID_MECHANICS.md](./GRID_MECHANICS.md).
-5. **Cooldowns** — 15s between successful refreshes, 30s after failures (`useLandSync.js`).
+5. **Cooldowns** — 15s between successful refreshes, 30s after failures, armed by the coordinator on every network hit (`useLandSync.js` only renders the countdown UI).
 
 ## Key composables
 
@@ -143,7 +145,7 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 | `useGridEngine.js` ⭐ | Core 10×10 grid + auto neighbor-hint propagation |
 | `useGridManager.js` | User marks / manual hint cycling |
 | `useLandData.js` ⭐ | Central land-data store + localStorage cache; `solverPatternKeys` is the historical-aware solver-input source shared by Grid.vue/TodayPatterns.vue on both digging pages |
-| `useLandSync.js` | Refresh cooldowns, `bypassCache` |
+| `useLandSync.js` | Refresh UI state (isLoading/isCooldown/countdown) — network decisions delegated to `landFetchCoordinator` |
 | `useDigDayStore.js` | Hub dig-day sync (debounce/ETag/merge) — see [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md) |
 | `usePracticeEngine.js` / `usePracticePatterns.js` | Practice mode grid generation + daily patterns |
 | `useHintsStorage.js` | Per-land per-UTC-day hint persistence |
@@ -156,7 +158,7 @@ Parameterized key builders: `landDataKey(id, testApi)`, `landCooldownKey(id, tes
 
 ## Services (`src/services/`)
 
-All hit the `/api/*` Netlify proxies. `landApiService.js`, `landSyncService.js`, `digDayApiService.js`, `hubAuthService.js`, `hubProfileService.js`, `practiceHubService.js`, `practicePatternService.js`, `practiceRunApiService.js`, `adminBlobService.js`. Hub calls attach `Authorization: Bearer <token>` via `src/features/hub/hubClient.js` when a session exists.
+All hit the `/api/*` Netlify proxies — per-service reference in [../src/services/README.md](../src/services/README.md). `landFetchCoordinator.js` ⭐ is the single door to the SFL farm API (single-flight, freshness, cooldown — see [API_LAYER.md](./API_LAYER.md)); `landApiService.js`, `landSyncService.js`, `digDayApiService.js`, `hubAuthService.js`, `hubProfileService.js`, `practiceHubService.js`, `practicePatternService.js`, `practiceRunApiService.js`, `adminBlobService.js`. Hub calls attach `Authorization: Bearer <token>` via `src/features/hub/hubClient.js` when a session exists.
 
 ## Grid builder utils (the 4 overlapping files)
 
@@ -193,6 +195,7 @@ Known non-functional or trap-laden spots. Documented so an AI doesn't waste time
 ## Related docs
 
 - [AGENTS.md](../AGENTS.md) — dev commands, conventions, env, API proxy quirks
+- [API_LAYER.md](./API_LAYER.md) — SFL farm API request pipeline + caching/cooldown policy
 - [GRID_MECHANICS.md](./GRID_MECHANICS.md) — grid engine, hints, formations, practice mode
 - [DIG_DAY_SYNC.md](./DIG_DAY_SYNC.md) — dig-day hub sync (debounce/ETag/merge)
 - [HUB_CONSUMPTION_SPEC.md](./HUB_CONSUMPTION_SPEC.md) — hub ETag/idempotency spec

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -111,7 +111,7 @@ exports.handler = async (event) => {
     logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
       statusCode: cached.statusCode,
-      headers: { ...corsHeaders, 'Cache-Control': 'public, max-age=60' },
+      headers: corsHeaders,
       body: cached.body,
     }
   }

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -27,6 +27,14 @@ function resolveApiTarget (event) {
 
 const corsHeaders = {
   'Content-Type': 'application/json',
+  // Explicit no-store: land data is dynamic per-farm, and leaving this unset
+  // lets netlify dev's fastify static layer apply its default 1h browser cache
+  // (public, max-age=3600) locally — which makes the refresh button look broken
+  // (browser serves the old body). In prod it guarantees no browser/CDN caching;
+  // the only cache is this function's 60s in-memory responseCache, which the
+  // x-sfl-bypass-cache header controls. If edge caching is ever wanted, switch
+  // to CDN-Cache-Control + Vary (see practice-patterns.cjs).
+  'Cache-Control': 'no-store',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, x-sfl-api-env, x-sfl-bypass-cache',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',

--- a/netlify/functions/sfl-api.cjs
+++ b/netlify/functions/sfl-api.cjs
@@ -111,7 +111,7 @@ exports.handler = async (event) => {
     logSflApi({ env, path: apiPath, landId, status: cached.statusCode, cache: 'hit' })
     return {
       statusCode: cached.statusCode,
-      headers: corsHeaders,
+      headers: { ...corsHeaders, 'Cache-Control': 'public, max-age=60' },
       body: cached.body,
     }
   }

--- a/src/components/LandLoader.vue
+++ b/src/components/LandLoader.vue
@@ -64,7 +64,7 @@ function goToLand() {
   if (shouldAutoFetch) {
     setTimeout(() => {
       const { reloadFromServer } = useLandSync({ landId: id })
-      reloadFromServer({ landId: id, skipCooldown: true })
+      reloadFromServer({ landId: id })
     }, 300)
   }
 }

--- a/src/components/RefreshLandData.vue
+++ b/src/components/RefreshLandData.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :disabled="isLoading || isCooldown || isHistoricalView"
-    @click="reloadFromServer"
+    @click="() => reloadFromServer({ bypassCache: true })"
     class="refresh-btn btn btn-primary btn-sm sm:btn-md text-xs sm:text-sm text-nowrap text-base-100"
   >
     <span v-if="isLoading" class="loading">⏳</span>

--- a/src/composables/useApiEnvironmentSwitch.js
+++ b/src/composables/useApiEnvironmentSwitch.js
@@ -28,7 +28,7 @@ export function useApiEnvironmentSwitch () {
     if (landId) {
       setTimeout(() => {
         const { reloadFromServer } = useLandSync({ landId })
-        reloadFromServer({ landId, force: true })
+        reloadFromServer({ landId, force: true, bypassCache: true })
       }, 100)
     }
   }

--- a/src/composables/useLandSync.js
+++ b/src/composables/useLandSync.js
@@ -1,13 +1,16 @@
 // src/composables/useLandSync.js
+//
+// Thin UI wrapper over landFetchCoordinator. Owns the visible refresh state
+// (isLoading / isCooldown / remaining countdown); ALL network decisions live
+// in the coordinator (freshness, single-flight, cooldown, bypass policy).
+
 import { ref, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useLandData } from '@/composables/useLandData'
-import { fetchLandData } from '@/services/landSyncService'
+import { requestLandData } from '@/services/landFetchCoordinator'
 import { getLandCooldownStorageKey } from '@/config/api.js'
 
 const instances = new Map()
-const SUCCESS_COOLDOWN_MS = 15_000
-const FAILURE_COOLDOWN_MS = 30_000
 
 export function useLandSync (opts = {}) {
   let landId
@@ -36,6 +39,7 @@ export function useLandSync (opts = {}) {
     }
 
     function startCountdown (endTime) {
+      clearInterval(intervalId)
       isCooldown.value = true
       intervalId = setInterval(() => {
         const msLeft = endTime - Date.now()
@@ -55,40 +59,39 @@ export function useLandSync (opts = {}) {
     onBeforeUnmount(() => clearInterval(intervalId))
 
     async function reloadFromServer (opts = {}) {
-      const { force = false, skipCooldown = false, landId: overrideLandId } = opts
+      const { force = false, bypassCache = false, landId: overrideLandId } = opts
       const targetLandId = overrideLandId || landId
       if (isLoading.value || (isCooldown.value && !force)) return
 
       isLoading.value = true
 
       try {
-        const fresh = await fetchLandData(targetLandId, { bypassCache: true })
+        const data = await requestLandData(targetLandId, { force, bypassCache })
         lastFetchFailed = false
-        landData.value = {
-          date: new Date().toISOString().slice(0, 10),
-          fetchedAt: Date.now(),
-          ...fresh,
+
+        // Suppressed (cooldown active, nothing new) — keep current data as-is.
+        if (!data) return
+
+        landData.value = data
+
+        const desertDigging = data.visitedFarmState?.desert?.digging
+        const username = data.visitedFarmState?.username
+        if (desertDigging) {
+          window.dispatchEvent(
+            new CustomEvent('landDataReady', {
+              detail: { desertDigging, username },
+            }),
+          )
         }
-
-        const desertDigging = fresh.visitedFarmState.desert.digging
-        const username = fresh.visitedFarmState.username
-
-        window.dispatchEvent(
-          new CustomEvent('landDataReady', {
-            detail: { desertDigging, username },
-          }),
-        )
       } catch (err) {
         lastFetchFailed = true
         alert(err.message || 'An unexpected error occurred while loading land data.')
       } finally {
         isLoading.value = false
-
-        if (!force && !skipCooldown && !isCooldown.value) {
-          const cooldownMs = lastFetchFailed ? FAILURE_COOLDOWN_MS : SUCCESS_COOLDOWN_MS
-          const endTime = Date.now() + cooldownMs
-          localStorage.setItem(cooldownKey, String(endTime))
-          startCountdown(endTime)
+        // Re-sync the cooldown UI from the coordinator's authoritative state.
+        const end = Number(localStorage.getItem(cooldownKey))
+        if (end > Date.now()) {
+          startCountdown(end)
         }
       }
     }

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,24 @@
+# src/services/ — network layer
+
+Every service here calls a `/api/*` Netlify proxy. One rule: **land-data requests
+must go through `landFetchCoordinator.js`**, never straight to `landApiService`.
+See [docs/API_LAYER.md](../../docs/API_LAYER.md) for the full pipeline + policy.
+
+| Service | Endpoint(s) | Purpose | Callers | Caching / dedup |
+|---|---|---|---|---|
+| `landFetchCoordinator.js` ⭐ | (none — orchestrates) | **The only door to the SFL farm API**: single-flight, 5-min localStorage freshness, cooldown, bypass policy | `useLandSync`, `PracticeDigging.vue` | single-flight per `env:landId`, localStorage TTL, 15/30s cooldown |
+| `landApiService.js` | `/.netlify/functions/sfl-api/community/farms/:id` (+ `/visit/` fallback) | Raw fetch to the SFL API proxy; prod→test env fallback; 429 mapping | `landSyncService` only (via coordinator) | none client-side (proxy has 60s cache) |
+| `landSyncService.js` | (delegates) | Thin wrapper: rethrows 429 with friendly message | `landFetchCoordinator` | none |
+| `practicePatternService.js` | `/api/practice-patterns?utcDate=` | Today's / past-date formation patterns from the hub | `usePracticePatterns` | per-day localStorage cache + single-flight (in composable) |
+| `digDayApiService.js` | `/api/dig-day` | Fetch/save dig-day snapshots (ETag + idempotent writes) | `useDigDayStore`, history views | ETag revalidation + freshness cache (see DIG_DAY_SYNC.md) |
+| `hubAuthService.js` | `/api/hub-auth` | OTP send/verify, session token | `useHubSession`, login views | none (auth) |
+| `hubProfileService.js` | `/api/hub-profile` | Hub user profile read/write | account views | none |
+| `practiceHubService.js` | `/api/practice-runs` | Submit practice runs, score settings, nickname | `PracticeDigging.vue` | none (writes) |
+| `practiceRunApiService.js` | `/api/practice-run?id=` | Fetch a single saved practice run for replay | `PracticeDigging.vue` replay | none |
+| `adminBlobService.js` | `/api/admin-blobs` | Admin blob storage (solver fixtures etc.) | `/admin` | none |
+
+Hub calls attach `Authorization: Bearer <jwt>` when a session exists — that lives
+in `src/features/hub/hubClient.js` (`hubAuthHeaders()`).
+
+Do **not** add a new service that calls the SFL farm API directly. Extend the
+coordinator instead.

--- a/src/services/landFetchCoordinator.js
+++ b/src/services/landFetchCoordinator.js
@@ -1,0 +1,125 @@
+// src/services/landFetchCoordinator.js
+//
+// The ONLY door to the Sunflower Land farm API.
+//
+// Every component/composable that needs live land data goes through
+// requestLandData() — never call fetchLandDataFromServer() directly.
+//
+// Policy (full table in docs/API_LAYER.md):
+//   - Auto loads   -> serve the localStorage cache while it is fresh
+//                     (< LAND_CACHE_FRESH_MS); otherwise fetch through the
+//                     proxy's own 60s cache (no bypass header).
+//   - User refresh -> bypassCache: true (skip freshness AND the proxy cache),
+//                     still respects the 15s cooldown.
+//   - Env switch   -> force: true (skip freshness AND cooldown).
+//   - Single-flight: concurrent requests for the same (env, landId) share one
+//     network call — same pattern as usePracticePatterns' ongoingFetch.
+//   - Every network hit (success or failure) arms the localStorage cooldown.
+
+import { fetchLandData } from '@/services/landSyncService'
+import {
+  getLandCooldownStorageKey,
+  getLandDataStorageKey,
+  isTestApiEnvironment,
+} from '@/config/api.js'
+import { LAND_CACHE_FRESH_MS } from '@/utils/landCache.js'
+
+const SUCCESS_COOLDOWN_MS = 15_000
+const FAILURE_COOLDOWN_MS = 30_000
+
+// Module-scoped single-flight map: `${env}:${landId}` -> in-flight Promise.
+const inflight = new Map()
+
+const hasWindow = () => typeof window !== 'undefined'
+const todayUTC = () => new Date().toISOString().slice(0, 10)
+
+function requestKey (landId) {
+  return `${isTestApiEnvironment() ? 'test' : 'production'}:${String(landId)}`
+}
+
+function readCacheEnvelope (landId) {
+  if (!hasWindow()) return null
+  try {
+    return JSON.parse(localStorage.getItem(getLandDataStorageKey(landId)) || 'null')
+  } catch {
+    return null
+  }
+}
+
+/** The stored envelope `{ date, fetchedAt, visitedFarmState, ... }` or null. */
+export function readLandCache (landId) {
+  return readCacheEnvelope(landId) || null
+}
+
+/** Envelope only when it is for today AND younger than maxAgeMs. */
+export function readFreshLandCache (landId, maxAgeMs = LAND_CACHE_FRESH_MS) {
+  const raw = readCacheEnvelope(landId)
+  if (!raw || raw.date !== todayUTC() || !raw.visitedFarmState) return null
+  if (!raw.fetchedAt || Date.now() - raw.fetchedAt > maxAgeMs) return null
+  return raw
+}
+
+export function isCooldownActive (landId) {
+  if (!hasWindow()) return false
+  const end = Number(localStorage.getItem(getLandCooldownStorageKey(landId)) || 0)
+  return end > Date.now()
+}
+
+function armCooldown (landId, ms) {
+  if (!hasWindow()) return
+  localStorage.setItem(getLandCooldownStorageKey(landId), String(Date.now() + ms))
+}
+
+function writeCache (landId, data) {
+  if (!hasWindow()) return
+  localStorage.setItem(
+    getLandDataStorageKey(landId),
+    JSON.stringify({ date: todayUTC(), fetchedAt: Date.now(), ...data }),
+  )
+}
+
+/**
+ * Fetch land data with dedup + freshness + cooldown policy.
+ *
+ * @param {string} landId
+ * @param {{ force?: boolean, bypassCache?: boolean }} [options]
+ * @returns {Promise<object|null>} Envelope `{ date, fetchedAt, visitedFarmState }`,
+ *   or null when the call was suppressed (cooldown active, nothing cached).
+ */
+export async function requestLandData (landId, { force = false, bypassCache = false } = {}) {
+  if (!landId) throw new Error('landId is required')
+  const key = requestKey(landId)
+
+  // 1. Fresh cache short-circuit — auto loads only. A user refresh
+  //    (bypassCache) explicitly wants to re-hit the server.
+  if (!force && !bypassCache) {
+    const fresh = readFreshLandCache(landId)
+    if (fresh) return fresh
+  }
+
+  // 2. Cooldown: suppress the network call, still serve whatever we have.
+  //    Navigation/mounts never pile requests onto a busy server.
+  if (!force && isCooldownActive(landId)) {
+    return readLandCache(landId)
+  }
+
+  // 3. Single-flight: concurrent callers share one network request.
+  if (inflight.has(key)) return inflight.get(key)
+
+  const promise = (async () => {
+    const data = await fetchLandData(landId, { bypassCache })
+    writeCache(landId, data)
+    armCooldown(landId, SUCCESS_COOLDOWN_MS)
+    return { date: todayUTC(), fetchedAt: Date.now(), ...data }
+  })()
+
+  inflight.set(key, promise)
+  try {
+    return await promise
+  } catch (err) {
+    armCooldown(landId, FAILURE_COOLDOWN_MS)
+    throw err
+  } finally {
+    inflight.delete(key)
+  }
+}

--- a/src/views/Digging.vue
+++ b/src/views/Digging.vue
@@ -260,7 +260,7 @@ onMounted(async () => {
     const { shouldAutoFetch } = readLandCacheMeta(routeLandId)
     if (shouldAutoFetch) {
       const { reloadFromServer } = useLandSync({ landId: routeLandId })
-      reloadFromServer({ landId: routeLandId, skipCooldown: true })
+      reloadFromServer({ landId: routeLandId })
     }
   }
 })

--- a/src/views/PracticeDigging.vue
+++ b/src/views/PracticeDigging.vue
@@ -233,7 +233,7 @@ import PracticePatterns from '@/components/PracticePatterns.vue'
 import InfoFooter from '@/components/InfoFooter.vue'
 import { submitPracticeRun, isPracticeSaveScoresEnabled, setPracticeSaveScoresEnabled, getNickname, setNickname } from '@/services/practiceHubService.js'
 import { fetchPracticeRun } from '@/services/practiceRunApiService.js'
-import { fetchLandDataFromServer } from '@/services/landApiService.js'
+import { requestLandData } from '@/services/landFetchCoordinator'
 import { getTodayUTC } from '@/utils/buildDigTimeline.js'
 import { buildPracticeDigTimeline } from '@/utils/buildPracticeDigTimeline.js'
 import { encodeBoard, decodeBoard } from '@/utils/practiceBoardCode.js'
@@ -592,7 +592,8 @@ async function startLandRound (landId) {
   todayRoundErrorMessage.value = ''
   lastRunId.value = null
   try {
-    const data = await fetchLandDataFromServer(landId)
+    const data = await requestLandData(landId)
+    if (!data) throw new Error('Land data is not available right now. Please try again shortly.')
     const patterns = data?.visitedFarmState?.desert?.digging?.patterns || []
     if (!patterns.length) throw new Error('No patterns found for that land.')
     isReplayMode.value = false


### PR DESCRIPTION
## What

Fixes the SFL farm API being called redundantly on refresh/navigation. All land-data requests now go through ONE coordinator (`src/services/landFetchCoordinator.js`) instead of three independent paths with inconsistent flags.

## Why

| Finding | Before |
|---|---|
| `reloadFromServer` always sent `bypassCache: true` | The proxy's 60s cache was dead for the entire app flow — every sync hit the SFL API |
| `skipCooldown: true` unchecked in guard, skipped *arming* cooldown | Auto-fetch callers (LandLoader, Digging onMounted) fired unthrottled |
| `PracticeDigging.vue` called `fetchLandDataFromServer()` directly | A third path with no single-flight, no cooldown, no freshness check |
| No single-flight for land data | LandLoader `setTimeout(300)` + Digging `onMounted` could double-fire |
| `landCache.js` 5-min freshness was advisory | Nothing enforced it |

## Changes

- **NEW `src/services/landFetchCoordinator.js`** — the single door: `requestLandData(landId, { force, bypassCache })` with single-flight per `env:landId`, 5-min localStorage freshness, cooldown armed on every network hit (15s success / 30s failure).
- **`useLandSync.js`** — slimmed to UI state (isLoading/isCooldown/countdown); all network decisions delegated to the coordinator; fixed the interval leak.
- **Callers** — LandLoader/Digging drop `skipCooldown` (auto path); RefreshLandData sends `bypassCache: true` (user wants fresh, still respects cooldown); env switch is `force: true, bypassCache: true` (the only force caller); PracticeDigging uses the coordinator.
- **`sfl-api.cjs`** — `Cache-Control: public, max-age=60` on proxy cache hits so the CDN absorbs repeat loads.
- **Docs** — NEW `docs/API_LAYER.md` (pipeline diagram, trigger-point table, caching-layers table, policy table, golden rules), NEW `src/services/README.md` per-service reference, AGENTS.md + ARCHITECTURE.md updated (incl. fixing the stale "bypass on every sync" claim).

## Policy contract

| Caller intent | force | bypassCache | Result |
|---|---|---|---|
| Auto load (mount/navigation/practice round) | false | false | serve cache if <5 min old, else 1 fetch through proxy cache |
| "Refresh Data" button | false | true | fresh from SFL API, respects 15s cooldown |
| Prod ↔ testnet switch | true | true | fresh from other server, skips cooldown |

## Verification

- `npm test` — 56/56 pass (solver/transform untouched)
- `npm run build` — clean