### PR TITLE
solver: cross-shape overlap exclusion (Layer 1) + remaining-instance reporting (Layer 3) + 14-scenario corpus

### DIFF
--- a/docs/GRID_MECHANICS.md
+++ b/docs/GRID_MECHANICS.md
@@ -173,6 +173,9 @@ The solve is synchronous and instant (no cap, no idle callback needed). It is ca
 - `guaranteedSlugs: Map<idx, slug>` — treasure image slug, present only when the name is unambiguous
 - `guaranteedCandidates: Map<idx, slug[]>` — for guaranteed-but-ambiguous cells, the disputed identities the solver is still weighing (feeds the UI "?" tooltip: "could be: camel bone, otter pebble"); cleared when a name is proven
 - `guaranteedFormationCounts: Map<key, count>` — whole-pattern guarantees (see finalization)
+- `remainingCounts: Map<key, n>` — instances still unconfirmed per shape (Layer 3 reporting; absent = fully proven)
+- `remainingRegions: Map<key, Set<idx>>` — for each shape with remaining instances, the union of its still-legal placements = the cells that can still host one of its treasures ("where can it still be?"); computed from the same survivor sets the solver reasons over, so it can never contradict the deduction
+- `possibleTreasureCells: Set<idx>` — union of every remaining region (a cell absent from this set is provably NOT an undiscovered treasure)
 
 ### Testing the solver
 

--- a/src/composables/usePredictionEngine.js
+++ b/src/composables/usePredictionEngine.js
@@ -12,6 +12,9 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
   const guaranteedSlugs = ref(new Map())
   const guaranteedCandidates = ref(new Map())
   const guaranteedFormationCounts = ref(new Map())
+  const remainingCounts = ref(new Map())
+  const remainingRegions = ref(new Map())
+  const possibleTreasureCells = ref(new Set())
 
   const schedule = (typeof window !== 'undefined' && window.requestIdleCallback)
     ? window.requestIdleCallback.bind(window)
@@ -28,6 +31,9 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     guaranteedSlugs.value = result.guaranteedSlugs
     guaranteedCandidates.value = result.guaranteedCandidates
     guaranteedFormationCounts.value = result.guaranteedFormationCounts
+    remainingCounts.value = result.remainingCounts
+    remainingRegions.value = result.remainingRegions
+    possibleTreasureCells.value = result.possibleTreasureCells
   }
 
   function recompute() {
@@ -38,6 +44,9 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
       guaranteedSlugs.value = new Map()
       guaranteedCandidates.value = new Map()
       guaranteedFormationCounts.value = new Map()
+      remainingCounts.value = new Map()
+      remainingRegions.value = new Map()
+      possibleTreasureCells.value = new Set()
       return
     }
 
@@ -63,5 +72,5 @@ export function usePredictionEngine(tilesRef, patternKeysRef, enabledRef, { grid
     { immediate: true, deep: true }
   )
 
-  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts }
+  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts, remainingCounts, remainingRegions, possibleTreasureCells }
 }

--- a/src/dev/solverScenariosMechanics.js
+++ b/src/dev/solverScenariosMechanics.js
@@ -1,0 +1,229 @@
+// src/dev/solverScenariosMechanics.js
+//
+// Mechanics-combination scenarios — the "patterns × grid × rules" matrix:
+// duplicate formations, shared-name collisions, sparse digs, edge pins,
+// crab forcing, honest ambiguity. All assertions are TRUE against the current
+// (pre-Layer-1) solver — these lock in sound behavior across the combination
+// space. Non-seasonal formations only, except artefact boards which reference
+// the seasonal artefact by computed name (stable across seasons).
+//
+// idx = y*10 + x — every assertion below was hand-verified against the grid.
+//
+// The same array feeds BOTH the vitest auto-suite (tests/solver.scenarios.test.js)
+// and the /solver-debug page (src/views/SolverDebug.vue) — one source of truth.
+
+import { getCurrentSeasonalArtefact } from '@/data/game/seasonalArtefacts.js'
+
+const SEASONAL = getCurrentSeasonalArtefact()
+const SEASONAL_SLUG = SEASONAL.toLowerCase().replace(/\s+/g, '_')
+
+export const SOLVER_SCENARIOS_MECHANICS = [
+  {
+    id: 'mech-dup-cockle-partial',
+    name: 'M1 — duplicate COCKLEs: one pinned at corner, other honestly ambiguous',
+    grid: [
+      { x: 0, y: 0, items: { 'Cockle Shell': 1 } },
+      { x: 5, y: 5, items: { 'Cockle Shell': 1 } },
+    ],
+    patterns: ['COCKLE', 'COCKLE'],
+    assertions: [
+      { idx: 0, property: 'guaranteed', expected: true, label: 'A1 dug Cockle Shell guaranteed' },
+      { idx: 11, property: 'guaranteed', expected: true, label: 'B2 guaranteed (corner-pinned instance)' },
+      { idx: 11, property: 'slug', expected: 'cockle_shell', label: 'B2 slug = cockle_shell' },
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 guaranteed (corner-pinned instance)' },
+      { idx: 22, property: 'slug', expected: 'cockle_shell', label: 'C3 slug = cockle_shell' },
+      { idx: 33, property: 'guaranteed', expected: false, label: 'D4 NOT guaranteed (alternative diagonal)' },
+      { idx: 44, property: 'guaranteed', expected: false, label: 'E5 NOT guaranteed (alternative diagonal)' },
+      { idx: 66, property: 'guaranteed', expected: false, label: 'G7 NOT guaranteed (alternative diagonal)' },
+      { idx: 77, property: 'guaranteed', expected: false, label: 'H8 NOT guaranteed (alternative diagonal)' },
+    ],
+  },
+  {
+    id: 'mech-dup-hieroglyph-both-pinned',
+    name: 'M3 — duplicate HIEROGLYPHs, each pinned by its Hieroglyph tile',
+    grid: [
+      { x: 2, y: 3, items: { Hieroglyph: 1 } },
+      { x: 6, y: 7, items: { Hieroglyph: 1 } },
+    ],
+    patterns: ['HIEROGLYPH', 'HIEROGLYPH'],
+    assertions: [
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 Vase (instance A)' },
+      { idx: 22, property: 'slug', expected: 'vase', label: 'C3 slug = vase' },
+      { idx: 23, property: 'guaranteed', expected: true, label: 'D3 Vase (instance A)' },
+      { idx: 66, property: 'guaranteed', expected: true, label: 'G7 Vase (instance B)' },
+      { idx: 66, property: 'slug', expected: 'vase', label: 'G7 slug = vase' },
+      { idx: 67, property: 'guaranteed', expected: true, label: 'H7 Vase (instance B)' },
+      { idx: 32, property: 'guaranteed', expected: true, label: 'C4 Hieroglyph (dug)' },
+      { idx: 76, property: 'guaranteed', expected: true, label: 'G8 Hieroglyph (dug)' },
+    ],
+  },
+  {
+    id: 'mech-shared-name-collision-one-vs-three',
+    name: 'M4 — shared-name collision: ARTEFACT_ONE vs single-tile ARTEFACT_THREE',
+    grid: [
+      { x: 0, y: 3, items: { [SEASONAL]: 1 } },
+      { x: 0, y: 4, items: { 'Camel Bone': 1 } },
+      { x: 0, y: 5, items: { 'Camel Bone': 1 } },
+      { x: 7, y: 7, items: { [SEASONAL]: 1 } },
+    ],
+    patterns: ['ARTEFACT_ONE', 'ARTEFACT_THREE'],
+    assertions: [
+      { idx: 30, property: 'guaranteed', expected: true, label: 'D4 seasonal (dug, ONE)' },
+      { idx: 40, property: 'guaranteed', expected: true, label: 'E5 Camel Bone (ONE pinned)' },
+      { idx: 40, property: 'slug', expected: 'camel_bone', label: 'E5 slug = camel_bone' },
+      { idx: 50, property: 'guaranteed', expected: true, label: 'F6 Camel Bone (ONE pinned)' },
+      { idx: 50, property: 'slug', expected: 'camel_bone', label: 'F6 slug = camel_bone' },
+      { idx: 77, property: 'guaranteed', expected: true, label: 'H8 seasonal (THREE, dug)' },
+      { idx: 77, property: 'slug', expected: SEASONAL_SLUG, label: 'H8 slug = seasonal' },
+      { idx: 31, property: 'guaranteed', expected: false, label: 'B4 NOT guaranteed (free single-tile spot)' },
+    ],
+  },
+  {
+    id: 'mech-sparse-single-unique-anchor',
+    name: 'M5 — sparse dig: single Hieroglyph reveal pins its two Vases',
+    grid: [{ x: 5, y: 5, items: { Hieroglyph: 1 } }],
+    patterns: ['HIEROGLYPH'],
+    assertions: [
+      { idx: 45, property: 'guaranteed', expected: true, label: 'F5 Vase guaranteed' },
+      { idx: 45, property: 'slug', expected: 'vase', label: 'F5 slug = vase' },
+      { idx: 46, property: 'guaranteed', expected: true, label: 'G5 Vase guaranteed' },
+      { idx: 46, property: 'slug', expected: 'vase', label: 'G5 slug = vase' },
+      { idx: 0, property: 'guaranteed', expected: false, label: 'A1 NOT guaranteed' },
+    ],
+  },
+  {
+    id: 'mech-corner-crab-forced',
+    name: 'M6 — corner crab with one open neighbour is forced',
+    grid: [
+      { x: 0, y: 0, items: { Crab: 1 } },
+      { x: 0, y: 1, items: { Crab: 1 } },
+    ],
+    patterns: ['HIEROGLYPH'], // unrelated shape present so Pass 4 runs
+    assertions: [
+      { idx: 1, property: 'guaranteed', expected: true, label: 'B1 forced (only open neighbour of A1 crab)' },
+      { idx: 11, property: 'guaranteed', expected: false, label: 'B2 NOT forced (two candidates for A2 crab)' },
+      { idx: 20, property: 'guaranteed', expected: false, label: 'A3 NOT forced' },
+    ],
+  },
+  {
+    id: 'mech-two-open-crab-not-forced',
+    name: 'M7 — crab with two open neighbours forces nothing',
+    grid: [{ x: 0, y: 0, items: { Crab: 1 } }],
+    patterns: ['HIEROGLYPH'],
+    assertions: [
+      { idx: 1, property: 'guaranteed', expected: false, label: 'B1 NOT guaranteed' },
+      { idx: 10, property: 'guaranteed', expected: false, label: 'A2 NOT guaranteed' },
+    ],
+  },
+  {
+    id: 'mech-edge-pinned-vertical-artefact',
+    name: 'M8 — ARTEFACT_FOUR pinned against the left edge by its seasonal tile',
+    grid: [{ x: 0, y: 5, items: { [SEASONAL]: 1 } }],
+    patterns: ['ARTEFACT_FOUR'],
+    assertions: [
+      { idx: 50, property: 'guaranteed', expected: true, label: 'F6 seasonal (dug)' },
+      { idx: 50, property: 'slug', expected: SEASONAL_SLUG, label: 'F6 slug = seasonal' },
+      { idx: 60, property: 'guaranteed', expected: true, label: 'F7 Camel Bone guaranteed' },
+      { idx: 60, property: 'slug', expected: 'camel_bone', label: 'F7 slug = camel_bone' },
+      { idx: 70, property: 'guaranteed', expected: true, label: 'F8 Camel Bone guaranteed' },
+      { idx: 80, property: 'guaranteed', expected: true, label: 'F9 Camel Bone guaranteed' },
+    ],
+  },
+  {
+    id: 'mech-coral-pearl-both-pinned',
+    name: 'M9 — CORAL + PEARL: unique centre names pin both vertical trios',
+    grid: [
+      { x: 2, y: 2, items: { Coral: 1 } },
+      { x: 6, y: 6, items: { Pearl: 1 } },
+    ],
+    patterns: ['CORAL', 'PEARL'],
+    assertions: [
+      { idx: 12, property: 'guaranteed', expected: true, label: 'B3 Stone (CORAL)' },
+      { idx: 12, property: 'slug', expected: 'stone', label: 'B3 slug = stone' },
+      { idx: 32, property: 'guaranteed', expected: true, label: 'B5 Stone (CORAL)' },
+      { idx: 32, property: 'slug', expected: 'stone', label: 'B5 slug = stone' },
+      { idx: 56, property: 'guaranteed', expected: true, label: 'F7 Stone (PEARL)' },
+      { idx: 56, property: 'slug', expected: 'stone', label: 'F7 slug = stone' },
+      { idx: 76, property: 'guaranteed', expected: true, label: 'F9 Stone (PEARL)' },
+      { idx: 22, property: 'slug', expected: 'coral', label: 'C4 slug = coral' },
+      { idx: 66, property: 'slug', expected: 'pearl', label: 'G8 slug = pearl' },
+    ],
+  },
+  {
+    id: 'mech-coral-pearl-honest-ambiguity',
+    name: 'M10 — CORAL + PEARL, one Stone reveal: centre cell provably treasure, name honestly disputed',
+    grid: [{ x: 2, y: 1, items: { Stone: 1 } }],
+    patterns: ['CORAL', 'PEARL'],
+    assertions: [
+      { idx: 12, property: 'guaranteed', expected: true, label: 'B3 Stone guaranteed' },
+      { idx: 12, property: 'slug', expected: 'stone', label: 'B3 slug = stone' },
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 guaranteed (Coral or Pearl — both cover it)' },
+      { idx: 32, property: 'guaranteed', expected: true, label: 'B5 Stone guaranteed' },
+      { idx: 32, property: 'slug', expected: 'stone', label: 'B5 slug = stone' },
+    ],
+  },
+  {
+    id: 'mech-dup-cockle-both-pinned',
+    name: 'M11 — duplicate COCKLEs, both pinned by corner reveals (instance consumption)',
+    grid: [
+      { x: 0, y: 0, items: { 'Cockle Shell': 1 } },
+      { x: 1, y: 1, items: { 'Cockle Shell': 1 } },
+      { x: 3, y: 0, items: { 'Cockle Shell': 1 } },
+    ],
+    patterns: ['COCKLE', 'COCKLE'],
+    assertions: [
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 guaranteed (instance A tail)' },
+      { idx: 22, property: 'slug', expected: 'cockle_shell', label: 'C3 slug = cockle_shell' },
+      { idx: 14, property: 'guaranteed', expected: true, label: 'E2 guaranteed (instance B middle)' },
+      { idx: 14, property: 'slug', expected: 'cockle_shell', label: 'E2 slug = cockle_shell' },
+      { idx: 25, property: 'guaranteed', expected: true, label: 'F3 guaranteed (instance B tail)' },
+      { idx: 25, property: 'slug', expected: 'cockle_shell', label: 'F3 slug = cockle_shell' },
+    ],
+  },
+  {
+    id: 'mech-combo-five-formations',
+    name: 'M15 — five formations on one board: mixed pins and honest open ends',
+    grid: [
+      { x: 1, y: 2, items: { Hieroglyph: 1 } },
+      { x: 4, y: 4, items: { 'Old Bottle': 1 } },
+      { x: 6, y: 0, items: { 'Cockle Shell': 1 } },
+      { x: 0, y: 6, items: { Wood: 1 } },
+      { x: 1, y: 6, items: { 'Wooden Compass': 1 } },
+    ],
+    patterns: ['HIEROGLYPH', 'OLD_BOTTLE', 'COCKLE', 'WOODEN_COMPASS'],
+    assertions: [
+      { idx: 11, property: 'guaranteed', expected: true, label: 'B2 Vase (HIEROGLYPH)' },
+      { idx: 11, property: 'slug', expected: 'vase', label: 'B2 slug = vase' },
+      { idx: 12, property: 'guaranteed', expected: true, label: 'C2 Vase (HIEROGLYPH)' },
+      { idx: 17, property: 'guaranteed', expected: true, label: 'H2 Cockle Shell (COCKLE tail)' },
+      { idx: 17, property: 'slug', expected: 'cockle_shell', label: 'H2 slug = cockle_shell' },
+      { idx: 28, property: 'guaranteed', expected: true, label: 'I3 Cockle Shell (COCKLE tail)' },
+      { idx: 62, property: 'guaranteed', expected: true, label: 'C7 Wood (WOODEN_COMPASS tail)' },
+      { idx: 62, property: 'slug', expected: 'wood', label: 'C7 slug = wood' },
+      { idx: 54, property: 'guaranteed', expected: false, label: 'E6 NOT guaranteed (OLD_BOTTLE still 4-way)' },
+      { idx: 55, property: 'guaranteed', expected: false, label: 'F6 NOT guaranteed (OLD_BOTTLE still 4-way)' },
+      { idx: 34, property: 'guaranteed', expected: false, label: 'E4 NOT guaranteed (OLD_BOTTLE alt)' },
+    ],
+  },
+  {
+    id: 'mech-dup-cockle-honest-ambiguity',
+    name: 'M16 — duplicate COCKLEs: mid-diagonal reveals guarantee only the shared tails',
+    grid: [
+      { x: 1, y: 1, items: { 'Cockle Shell': 1 } },
+      { x: 6, y: 1, items: { 'Cockle Shell': 1 } },
+    ],
+    patterns: ['COCKLE', 'COCKLE'],
+    assertions: [
+      { idx: 11, property: 'guaranteed', expected: true, label: 'B2 dug Cockle Shell guaranteed' },
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 guaranteed (in both instance-A candidates)' },
+      { idx: 22, property: 'slug', expected: 'cockle_shell', label: 'C3 slug = cockle_shell' },
+      { idx: 16, property: 'guaranteed', expected: true, label: 'G2 dug Cockle Shell guaranteed' },
+      { idx: 27, property: 'guaranteed', expected: true, label: 'H3 guaranteed (in both instance-B candidates)' },
+      { idx: 27, property: 'slug', expected: 'cockle_shell', label: 'H3 slug = cockle_shell' },
+      { idx: 0, property: 'guaranteed', expected: false, label: 'A1 NOT guaranteed (one candidate only)' },
+      { idx: 33, property: 'guaranteed', expected: false, label: 'D4 NOT guaranteed (one candidate only)' },
+      { idx: 5, property: 'guaranteed', expected: false, label: 'F1 NOT guaranteed (one candidate only)' },
+      { idx: 38, property: 'guaranteed', expected: false, label: 'I4 NOT guaranteed (one candidate only)' },
+    ],
+  },
+]

--- a/src/dev/solverScenariosOverlap.js
+++ b/src/dev/solverScenariosOverlap.js
@@ -1,0 +1,77 @@
+// src/dev/solverScenariosOverlap.js
+//
+// Layer-1 target scenarios: same-name cross-shape overlap exclusion.
+//
+// Mechanics: the real board has exactly ONE item per cell — two formation
+// instances can never share a cell. But all 24 artefact formations + 7 daily
+// formations share just two names ("Camel Bone" + the seasonal artefact), so a
+// candidate placement of one shape whose plots land on cells already PROVEN to
+// belong to another formation instance is currently accepted (names match) and
+// bloats the candidate set. These scenarios assert what the solver proves ONCE
+// candidate generation excludes cells committed to other instances.
+//
+// They FAIL against the pre-Layer-1 solver and PASS after the exclusion lands —
+// which is the point: they lock in the strengthened guarantee.
+//
+// idx = y*10 + x — hand-verified.
+
+import { getCurrentSeasonalArtefact } from '@/data/game/seasonalArtefacts.js'
+
+const SEASONAL = getCurrentSeasonalArtefact()
+const SEASONAL_SLUG = SEASONAL.toLowerCase().replace(/\s+/g, '_')
+
+export const SOLVER_SCENARIOS_OVERLAP = [
+  {
+    id: 'overlap-one-vs-twentyfour',
+    name: 'O1 — Layer 1: confirmed ARTEFACT_ONE excludes same-name overlapping TWENTY_FOUR candidate',
+    // ONE@(0,0) = {0 seasonal, 10 CB, 20 CB}; real TWENTY_FOUR@(2,1) = {12 CB, 13 OP, 14 CB, 22 CB, 24 CB}.
+    // Reveal 12 (CB) has three candidates: real (2,1), real (2,0), and spurious
+    // (0,1) whose CB plots land on ONE's committed 10/20 (names match, so the
+    // pre-Layer-1 solver keeps it). Excluding it shrinks the intersection from
+    // {12} to {12,14} — 14 becomes provable.
+    grid: [
+      { x: 0, y: 0, items: { [SEASONAL]: 1 } },
+      { x: 2, y: 1, items: { 'Camel Bone': 1 } },
+    ],
+    patterns: ['ARTEFACT_ONE', 'ARTEFACT_TWENTY_FOUR'],
+    assertions: [
+      { idx: 0, property: 'guaranteed', expected: true, label: 'A1 seasonal (dug, ONE)' },
+      { idx: 0, property: 'slug', expected: SEASONAL_SLUG, label: 'A1 slug = seasonal' },
+      { idx: 10, property: 'guaranteed', expected: true, label: 'A2 Camel Bone (ONE pinned)' },
+      { idx: 10, property: 'slug', expected: 'camel_bone', label: 'A2 slug = camel_bone' },
+      { idx: 20, property: 'guaranteed', expected: true, label: 'A3 Camel Bone (ONE pinned)' },
+      { idx: 12, property: 'guaranteed', expected: true, label: 'C2 Camel Bone (dug, TWENTY_FOUR)' },
+      { idx: 12, property: 'slug', expected: 'camel_bone', label: 'C2 slug = camel_bone' },
+      // Layer-1 delta: the spurious (0,1) candidate overlaps ONE's committed
+      // 10/20; once excluded, 14 falls inside the remaining intersection.
+      { idx: 14, property: 'guaranteed', expected: true, label: 'E2 Camel Bone (Layer 1: overlap candidate excluded)' },
+      { idx: 14, property: 'slug', expected: 'camel_bone', label: 'E2 slug = camel_bone' },
+      { idx: 13, property: 'guaranteed', expected: false, label: 'D2 NOT guaranteed (single candidate only)' },
+      { idx: 22, property: 'guaranteed', expected: false, label: 'C3 NOT guaranteed (missing from the (2,0) candidate)' },
+    ],
+  },
+  {
+    id: 'overlap-one-vs-seventeen',
+    name: 'O5 — Layer 1: confirmed ARTEFACT_ONE excludes same-name overlapping SEVENTEEN candidate',
+    grid: [
+      { x: 0, y: 0, items: { [SEASONAL]: 1 } },
+      { x: 1, y: 2, items: { 'Camel Bone': 1 } },
+    ],
+    patterns: ['ARTEFACT_ONE', 'ARTEFACT_SEVENTEEN'],
+    assertions: [
+      { idx: 0, property: 'guaranteed', expected: true, label: 'A1 seasonal (dug, ONE)' },
+      { idx: 0, property: 'slug', expected: SEASONAL_SLUG, label: 'A1 slug = seasonal' },
+      { idx: 10, property: 'guaranteed', expected: true, label: 'A2 Camel Bone (ONE pinned)' },
+      { idx: 20, property: 'guaranteed', expected: true, label: 'A3 Camel Bone (ONE pinned)' },
+      { idx: 21, property: 'guaranteed', expected: true, label: 'B3 Camel Bone (dug, SEVENTEEN)' },
+      { idx: 21, property: 'slug', expected: 'camel_bone', label: 'B3 slug = camel_bone' },
+      // Without Layer 1 the SEVENTEEN candidate overlapping ONE (A3) survives
+      // and only B3 is guaranteed.
+      { idx: 22, property: 'guaranteed', expected: true, label: 'C3 Camel Bone (Layer 1: overlap candidate excluded)' },
+      { idx: 22, property: 'slug', expected: 'camel_bone', label: 'C3 slug = camel_bone' },
+      { idx: 32, property: 'guaranteed', expected: true, label: 'C4 seasonal (Layer 1)' },
+      { idx: 32, property: 'slug', expected: SEASONAL_SLUG, label: 'C4 slug = seasonal' },
+      { idx: 31, property: 'guaranteed', expected: false, label: 'B4 NOT guaranteed (only in the spurious overlap candidate)' },
+    ],
+  },
+]

--- a/src/utils/treasureSolver.js
+++ b/src/utils/treasureSolver.js
@@ -83,7 +83,7 @@ function flattenTile(tile) {
  * @param {(string[]|string)[]} tiles - grid cells of CSS class arrays
  * @param {string[]} patternKeys - formation multiset on the board
  * @param {number} gridSize - default 10
- * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedCandidates: Map<number,string[]>, guaranteedFormationCounts: Map<string,number>, partial: boolean }}
+ * @returns {{ guaranteed: Set<number>, guaranteedSlugs: Map<number,string>, guaranteedCandidates: Map<number,string[]>, guaranteedFormationCounts: Map<string,number>, remainingCounts: Map<string,number>, remainingRegions: Map<string,Set<number>>, possibleTreasureCells: Set<number>, partial: boolean }}
  */
 export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   const guaranteed = new Set()
@@ -131,7 +131,16 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
   // adjacent to a revealed sand tile (and that neighbor isn't itself a plot of
   // this same placement), the placement cannot be real. This only ever removes
   // impossible candidates, so it can never drop the real placement.
-  const buildPlacement = (formation, ox, oy) => {
+  //
+  // Soundness of the committed-cell exclusion (Layer 1): the real board has
+  // exactly ONE item per cell — two formation instances can never share a
+  // treasure cell. A cell already proven to belong to a CONFIRMED instance
+  // (committedCellOrigin) therefore cannot host a plot of any other instance —
+  // including another instance of the SAME shape. Most artefact formations
+  // share the names "Camel Bone"/seasonal-artefact, so without this check a
+  // same-name overlapping candidate survives and bloats the candidate set,
+  // hiding guarantees the intersection would otherwise prove.
+  const buildPlacement = (key, formation, ox, oy) => {
     const plots = new Map()
     for (const p of formation) {
       const x = ox + p.x
@@ -141,6 +150,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       if (revealedSand.has(idx) || revealedCrab.has(idx)) return null
       const rn = revealedTreasureName.get(idx)
       if (rn !== undefined && !namesMatch(rn, p.name)) return null
+      if (committedCellOrigin.has(idx)) return null
       plots.set(idx, p.name)
     }
     // Sand-adjacency: no plot may sit orthogonally next to revealed sand.
@@ -299,7 +309,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
         if (!namesMatch(anchor.name, tName)) continue
         const ox = tx - anchor.x
         const oy = ty - anchor.y
-        const plots = buildPlacement(formation, ox, oy)
+        const plots = buildPlacement(key, formation, ox, oy)
         if (!plots) continue
         // Cross-check for single-remaining-instance shapes: every revealed
         // treasure whose name is confined to this key — and not already
@@ -350,7 +360,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     const allPlacements = []
     for (let oy = -minY; oy <= gridSize - 1 - maxY; oy++) {
       for (let ox = -minX; ox <= gridSize - 1 - maxX; ox++) {
-        const plots = buildPlacement(formation, ox, oy)
+        const plots = buildPlacement(key, formation, ox, oy)
         if (plots) allPlacements.push(plots)
       }
     }
@@ -376,7 +386,7 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
       const survivors = []
       for (const anchor of formation) {
         if (!namesMatch(anchor.name, aName)) continue
-        const plots = buildPlacement(formation, ax - anchor.x, ay - anchor.y)
+        const plots = buildPlacement(key, formation, ax - anchor.x, ay - anchor.y)
         if (!plots) continue
         const coversAll = confined.every(([cIdx, cName]) => namesMatch(plots.get(cIdx), cName))
         if (coversAll) survivors.push(plots)
@@ -844,5 +854,36 @@ export function solveTreasures(tiles, patternKeys, gridSize = 10) {
     if (count > 0) guaranteedFormationCounts.set(key, count)
   }
 
-  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts, partial: false }
+  // ── Layer 3: remaining-instance reporting ────────────────────────────
+  // Pure reporting — never feeds deduction. For every shape with unconfirmed
+  // instances left, HOW MANY remain and WHICH cells can still host one of
+  // them. A region is the union of all still-legal placements (buildPlacement
+  // already excludes sand/crab/name-mismatch/committed cells), so a cell
+  // absent from every region is provably NOT an undiscovered treasure — the
+  // complement of `guaranteed`. This answers "what's still out there, and
+  // where can it still be?" for the UI.
+  const remainingCounts = new Map()
+  const remainingRegions = new Map()
+  for (const key of presentKeys) {
+    const rem = remainingCount.get(key) ?? 0
+    if (rem === 0) continue
+    remainingCounts.set(key, rem)
+    // Tighter survivor set when a single instance remains (Pass 2/3
+    // semantics), full-board enumeration otherwise — same sets the solver
+    // itself reasons over, so the report can never contradict the deduction.
+    const placements = rem === 1
+      ? enumerateSingleInstanceSurvivors(key)
+      : enumerateAllPlacements(key)
+    const region = new Set()
+    for (const p of placements) {
+      for (const idx of p.keys()) region.add(idx)
+    }
+    remainingRegions.set(key, region)
+  }
+  const possibleTreasureCells = new Set()
+  for (const region of remainingRegions.values()) {
+    for (const idx of region) possibleTreasureCells.add(idx)
+  }
+
+  return { guaranteed, guaranteedSlugs, guaranteedCandidates, guaranteedFormationCounts, remainingCounts, remainingRegions, possibleTreasureCells, partial: false }
 }

--- a/src/views/SolverDebug.vue
+++ b/src/views/SolverDebug.vue
@@ -44,6 +44,9 @@
         <p class="text-xs opacity-60">
           guaranteed: {{ liveResult.guaranteedCount }} cells
         </p>
+        <p class="text-xs opacity-60">
+          remaining: {{ liveResult.remainingSummary }}
+        </p>
       </div>
     </div>
 
@@ -70,6 +73,11 @@
         </div>
       </div>
 
+      <!-- Remaining-instance report (Layer 3) -->
+      <p class="text-xs opacity-60 mb-1">
+        remaining: {{ s.remainingSummary }}
+      </p>
+
       <!-- Assertions list -->
       <ul class="text-sm space-y-0.5">
         <li v-for="a in s.assertions" :key="a.label" :class="a.ok ? 'text-success' : 'text-error'">
@@ -86,6 +94,14 @@ import { ref, onMounted } from 'vue'
 import { solveTreasures } from '@/utils/treasureSolver.js'
 import { gridArrayToTiles } from '@/utils/gridTileTransform.js'
 import { SOLVER_SCENARIOS } from '@/dev/solverScenarios.js'
+import { SOLVER_SCENARIOS_MECHANICS } from '@/dev/solverScenariosMechanics.js'
+import { SOLVER_SCENARIOS_OVERLAP } from '@/dev/solverScenariosOverlap.js'
+
+const ALL_SCENARIOS = [
+  ...SOLVER_SCENARIOS,
+  ...SOLVER_SCENARIOS_MECHANICS,
+  ...SOLVER_SCENARIOS_OVERLAP,
+]
 
 const SLUG_ABBR = {
   camel_bone: 'CB', salt_dino_egg: 'SDE', cockle_shell: 'CK',
@@ -96,9 +112,18 @@ const SLUG_ABBR = {
 
 const G = 10
 
+function buildRemainingSummary(remainingCounts, remainingRegions) {
+  const parts = []
+  for (const [key, n] of remainingCounts) {
+    const regionSize = remainingRegions.get(key)?.size ?? 0
+    parts.push(`${key} ×${n}${regionSize ? ` (${regionSize} cells)` : ''}`)
+  }
+  return parts.length ? parts.join(', ') : 'none — all instances proven'
+}
+
 function evalScenario(scenario) {
   const tiles = gridArrayToTiles(scenario.grid, G)
-  const { guaranteed, guaranteedSlugs } = solveTreasures(tiles, scenario.patterns, G)
+  const { guaranteed, guaranteedSlugs, remainingCounts, remainingRegions } = solveTreasures(tiles, scenario.patterns, G)
 
   const cells = Array.from({ length: G * G }, (_, idx) => {
     const tileClasses = tiles[idx] || []
@@ -150,6 +175,7 @@ function evalScenario(scenario) {
     pass: assertions.every(a => a.ok),
     cells,
     assertions,
+    remainingSummary: buildRemainingSummary(remainingCounts, remainingRegions),
   }
 }
 
@@ -204,12 +230,13 @@ async function loadLiveLand() {
     const rawGrid = digging.grid || []
     const patterns = digging.patterns || []
     const tiles = gridArrayToTiles(rawGrid, G)
-    const { guaranteed, guaranteedSlugs } = solveTreasures(tiles, patterns, G)
+    const { guaranteed, guaranteedSlugs, remainingCounts, remainingRegions } = solveTreasures(tiles, patterns, G)
     liveResult.value = {
       id,
       patterns,
       cells: buildCells(tiles, guaranteed, guaranteedSlugs),
       guaranteedCount: guaranteed.size,
+      remainingSummary: buildRemainingSummary(remainingCounts, remainingRegions),
     }
   } catch (err) {
     liveError.value = err?.message || 'Failed to load land data.'
@@ -220,6 +247,6 @@ async function loadLiveLand() {
 
 const results = ref([])
 onMounted(() => {
-  results.value = SOLVER_SCENARIOS.map(evalScenario)
+  results.value = ALL_SCENARIOS.map(evalScenario)
 })
 </script>

--- a/tests/solver.oracle.test.js
+++ b/tests/solver.oracle.test.js
@@ -55,21 +55,33 @@ function legalOrigins(formation) {
 // Returns { tiles, patternKeys, truth } where truth = Set<idx> of all treasure
 // positions — the ground truth for the soundness check.
 
-function generateBoard(rng, numFormations) {
-  // Pick unique formation keys
+function generateBoard(rng, numFormations, opts = {}) {
+  // Pick keys: when opts.dupKey is set, that key appears TWICE and the rest are
+  // unique — exercising the duplicate-instance path the old generator never hit
+  // (the class that produced the double-consumption regressions).
   const keys = []
   const available = [...STABLE_KEYS]
-  for (let i = 0; i < numFormations && available.length; i++) {
+  if (opts.dupKey) {
+    const di = available.indexOf(opts.dupKey)
+    if (di >= 0) available.splice(di, 1)
+    else opts.dupKey = null
+  }
+  const uniqueNeeded = numFormations - (opts.dupKey ? 2 : 0)
+  for (let i = 0; i < uniqueNeeded && available.length; i++) {
     const j = Math.floor(rng() * available.length)
     keys.push(available[j])
     available.splice(j, 1)
+  }
+  if (opts.dupKey) {
+    keys.push(opts.dupKey)
+    keys.push(opts.dupKey)
   }
 
   // Place each formation at a random non-overlapping legal position
   const truth = new Set()
   const truthName = new Map() // idx -> plot name
   const placements = []
-  const keyToPlots = new Map() // key -> Map<idx, name> for this board's real placement
+  const keyToPlots = new Map() // key -> Map<idx, name>[] (one entry per real instance)
 
   for (const key of keys) {
     const formation = DIGGING_FORMATIONS[key]
@@ -87,7 +99,8 @@ function generateBoard(rng, numFormations) {
         truthName.set(idx, name)
       }
       placements.push(plots)
-      keyToPlots.set(key, plots)
+      if (!keyToPlots.has(key)) keyToPlots.set(key, [])
+      keyToPlots.get(key).push(plots)
       placed = true
       break
     }
@@ -137,14 +150,14 @@ function generateBoard(rng, numFormations) {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-function runSoundnessCheck(seeds, numFormations) {
+function runSoundnessCheck(seeds, numFormations, opts) {
   const failures = []
   const formationFailures = []
   let skipped = 0
 
   for (const seed of seeds) {
     const rng = makePrng(seed)
-    const board = generateBoard(rng, numFormations)
+    const board = generateBoard(rng, numFormations, opts)
     if (!board) { skipped++; continue }
 
     const { guaranteed, guaranteedSlugs, guaranteedFormationCounts } = solveTreasures(board.tiles, board.patternKeys, G)
@@ -161,22 +174,32 @@ function runSoundnessCheck(seeds, numFormations) {
     }
 
     // Pattern-level soundness: every key the solver claims is
-    // whole-pattern-guaranteed must have EVERY cell of its real (ground-truth)
-    // placement already in `guaranteed`, with a matching name where the solver
-    // reports one. This generator only ever picks unique keys, so `keyToPlots`
-    // unambiguously identifies "this formation's real placement".
+    // whole-pattern-guaranteed must have its REAL (ground-truth) placements
+    // covered — for a unique key, that single placement must be fully in
+    // `guaranteed` with matching names; for a duplicated key, the number of
+    // fully-covered real placements must be >= the claimed count (N confirmed
+    // instances are N distinct real instances, and each confirmed instance's
+    // cells are exactly one real placement's cells). `keyToPlots` now holds an
+    // array per key (one entry per real instance).
     for (const key of guaranteedFormationCounts.keys()) {
-      const plots = board.keyToPlots.get(key)
-      for (const [idx, name] of plots) {
-        const label = String.fromCharCode(65 + (idx % G)) + (Math.floor(idx / G) + 1)
-        if (!guaranteed.has(idx)) {
-          formationFailures.push({ seed, key, idx, label, reason: 'cell not in guaranteed' })
-          continue
-        }
-        const guessedName = guaranteedSlugs.get(idx)
-        const expectedSlug = name.toLowerCase().replace(/\s+/g, '_')
-        if (guessedName && guessedName !== expectedSlug) {
-          formationFailures.push({ seed, key, idx, label, reason: `named "${guessedName}", expected "${expectedSlug}"` })
+      const realPlaces = board.keyToPlots.get(key) || []
+      const fullyCovered = realPlaces.filter(plots =>
+        [...plots.keys()].every(idx => guaranteed.has(idx)),
+      ).length
+      const claimed = guaranteedFormationCounts.get(key)
+      if (fullyCovered < claimed) {
+        formationFailures.push({ seed, key, idx: -1, label: '(whole pattern)', reason: `claims ${claimed} instance(s) but only ${fullyCovered} real placement(s) fully covered` })
+        continue
+      }
+      for (const plots of realPlaces) {
+        for (const [idx, name] of plots) {
+          if (!guaranteed.has(idx)) continue // unclaimed cell is fine (incomplete, not unsound)
+          const label = String.fromCharCode(65 + (idx % G)) + (Math.floor(idx / G) + 1)
+          const guessedName = guaranteedSlugs.get(idx)
+          const expectedSlug = name.toLowerCase().replace(/\s+/g, '_')
+          if (guessedName && guessedName !== expectedSlug) {
+            formationFailures.push({ seed, key, idx, label, reason: `named "${guessedName}", expected "${expectedSlug}"` })
+          }
         }
       }
     }
@@ -214,5 +237,15 @@ describe('Soundness oracle — every guaranteed cell must be a real treasure', (
   it('no false positives across 100 random 3-formation boards', () => {
     const seeds = Array.from({ length: 100 }, (_, i) => i + 2001)
     expectNoFailures(runSoundnessCheck(seeds, 3))
+  })
+})
+
+describe('Soundness oracle — duplicate-key boards', () => {
+  it('no false positives across 100 boards with one formation placed twice', () => {
+    // 3 formations = one duplicated key + one unique (dupKey occupies 2 slots).
+    const seeds = Array.from({ length: 100 }, (_, i) => i + 3001)
+    for (const dupKey of ['COCKLE', 'OLD_BOTTLE', 'HIEROGLYPH']) {
+      expectNoFailures(runSoundnessCheck(seeds, 3, { dupKey }))
+    }
   })
 })

--- a/tests/solver.scenarios.test.js
+++ b/tests/solver.scenarios.test.js
@@ -935,9 +935,17 @@ describe('guaranteedCandidates — disputed-name reporting', () => {
 })
 
 import { SOLVER_SCENARIOS } from '@/dev/solverScenarios.js'
+import { SOLVER_SCENARIOS_MECHANICS } from '@/dev/solverScenariosMechanics.js'
+import { SOLVER_SCENARIOS_OVERLAP } from '@/dev/solverScenariosOverlap.js'
+
+const ALL_SCENARIOS = [
+  ...SOLVER_SCENARIOS,
+  ...SOLVER_SCENARIOS_MECHANICS,
+  ...SOLVER_SCENARIOS_OVERLAP,
+]
 
 describe('SOLVER_SCENARIOS auto-generated regression suite', () => {
-  for (const s of SOLVER_SCENARIOS) {
+  for (const s of ALL_SCENARIOS) {
     if (!s.assertions || s.assertions.length === 0) continue
     it(s.name, () => {
       const tiles = gridArrayToTiles(s.grid, G)
@@ -950,4 +958,77 @@ describe('SOLVER_SCENARIOS auto-generated regression suite', () => {
       }
     })
   }
+})
+
+describe('Layer 3 — remaining-instance reporting', () => {
+  it('reports the one unconfirmed COCKLE and its exact survivor region', () => {
+    // Duplicate COCKLEs: instance A pinned to the corner (cells 0,11,22), the
+    // other's diagonal can still be (3,3),(4,4),(5,5) — union {33,44,55,66,77}.
+    const tiles = makeTiles([
+      { x: 0, y: 0, items: { 'Cockle Shell': 1 } },
+      { x: 5, y: 5, items: { 'Cockle Shell': 1 } },
+    ])
+    const { remainingCounts, remainingRegions, possibleTreasureCells } = solveTreasures(tiles, ['COCKLE', 'COCKLE'], G)
+
+    expect(remainingCounts.get('COCKLE')).toBe(1)
+    expect(remainingCounts.size).toBe(1)
+    const region = remainingRegions.get('COCKLE')
+    expect([...region].sort((a, b) => a - b)).toEqual([33, 44, 55, 66, 77])
+    // The confirmed instance A cells (0,11,22) are NOT part of the remaining region.
+    for (const idx of [0, 11, 22]) expect(region.has(idx)).toBe(false)
+    expect(possibleTreasureCells.size).toBe(region.size)
+  })
+
+  it('reports nothing remaining when every instance is proven', () => {
+    // ONE fully confirmed at (0,3)-(0,5); THREE confirmed at (7,7). Layer 1
+    // keeps THREE's single-tile placement from being stolen by ONE's cells.
+    const tiles = makeTiles([
+      { x: 0, y: 3, items: { [SEASONAL]: 1 } },
+      { x: 0, y: 4, items: { 'Camel Bone': 1 } },
+      { x: 0, y: 5, items: { 'Camel Bone': 1 } },
+      { x: 7, y: 7, items: { [SEASONAL]: 1 } },
+    ])
+    const { remainingCounts, possibleTreasureCells } = solveTreasures(tiles, ['ARTEFACT_ONE', 'ARTEFACT_THREE'], G)
+
+    expect(remainingCounts.size).toBe(0)
+    expect(possibleTreasureCells.size).toBe(0)
+  })
+
+  it('bounds the unfound OLD_BOTTLE to the 9 cells of its four candidate placements', () => {
+    // M15 board: HIEROGLYPH / COCKLE / WOODEN_COMPASS all confirmed, OLD_BOTTLE
+    // still 4-way around the single (4,4) reveal. Survivor union = 9 cells.
+    const tiles = makeTiles([
+      { x: 1, y: 2, items: { Hieroglyph: 1 } },
+      { x: 4, y: 4, items: { 'Old Bottle': 1 } },
+      { x: 6, y: 0, items: { 'Cockle Shell': 1 } },
+      { x: 0, y: 6, items: { Wood: 1 } },
+      { x: 1, y: 6, items: { 'Wooden Compass': 1 } },
+    ])
+    const { remainingCounts, remainingRegions } = solveTreasures(
+      tiles, ['HIEROGLYPH', 'OLD_BOTTLE', 'COCKLE', 'WOODEN_COMPASS'], G,
+    )
+
+    expect(remainingCounts.size).toBe(1)
+    expect(remainingCounts.get('OLD_BOTTLE')).toBe(1)
+    const region = remainingRegions.get('OLD_BOTTLE')
+    expect([...region].sort((a, b) => a - b)).toEqual([33, 34, 35, 43, 44, 45, 53, 54, 55])
+  })
+
+  it('reports both instances of an unpinned duplicate formation (full-board region)', () => {
+    // M16 board: two COCKLEs, nothing confirmed. Region = union of every legal
+    // diagonal placement. A diagonal needs the same offset for x and y, so
+    // only cells where x and y are far apart in the wrong direction are
+    // unreachable: (8,0),(9,0),(9,1),(0,8),(1,9),(0,9) — 6 cells.
+    const tiles = makeTiles([
+      { x: 1, y: 1, items: { 'Cockle Shell': 1 } },
+      { x: 6, y: 1, items: { 'Cockle Shell': 1 } },
+    ])
+    const { remainingCounts, remainingRegions } = solveTreasures(tiles, ['COCKLE', 'COCKLE'], G)
+
+    expect(remainingCounts.get('COCKLE')).toBe(2)
+    const region = remainingRegions.get('COCKLE')
+    expect(region.size).toBe(94)
+    for (const idx of [8, 9, 19, 80, 90, 91]) expect(region.has(idx)).toBe(false)
+    for (const idx of [55, 11, 16]) expect(region.has(idx)).toBe(true)
+  })
 })


### PR DESCRIPTION
## What

**Layer 1 — cross-shape overlap exclusion** (src/utils/treasureSolver.js)
Candidate generation now rejects any plot landing on a cell already committed to a confirmed formation instance. The real board has exactly one item per cell, so this is provably sound — it only shrinks candidate sets, and shrinking them cascades (fewer candidates → single-candidate pins → more committed cells → fewer candidates). Most artefact formations share only 'Camel Bone' + the seasonal name, so same-name overlapping candidates were common and hid provable guarantees (O1: E2 newly provable; O5: C3+C4 newly provable — both locked in as failing-before/passing-after scenarios).

**Layer 3 — remaining-instance reporting** (pure addition, never feeds deduction)
solveTreasures now returns remainingCounts (unconfirmed instances per shape), remainingRegions (union of still-legal placements per shape — 'where can it still be?'), possibleTreasureCells (global union). Surfaced on the /solver-debug page and exposed through usePredictionEngine.

**Scenario corpus** — 14 new scenarios (src/dev/solverScenariosMechanics.js + solverScenariosOverlap.js) covering the patterns × grid × rules matrix: duplicate formations (both-pinned and honestly-ambiguous), shared-name collisions, sparse digs, edge pins, crab forcing, CORAL/PEARL name-dispute reporting, a 5-formation combo board. The scenario data is the single source of truth for BOTH the vitest auto-suite and the /solver-debug page.

**Oracle hardening** — duplicate-key boards (the class the oracle never generated, and the source of the earlier double-consumption regressions) with a fully-covered-real-placements ≥ claimed-count soundness check.

## Verify

- npm test: 78 passing (was 59) — soundness oracle (600 unique-key + 300 duplicate-key boards), scenarios, transform contract
- npm run build: clean
- /solver-debug shows every scenario as a board with PASS/FAIL + 'remaining:' report

## Known notes

- This branch already carries commit 2809487 'dev: expose dev server on the network' (vite.config host:true/allowedHosts:true) from earlier work — dev-only, no effect on builds/deploys. Say the word and I'll add a revert commit.
- Cloudflare Pages GitHub-App checks may show failing even when Netlify previews pass (known misconfigured-project issue; fix is a dashboard-side disconnect, not a repo change).